### PR TITLE
Initial plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -449,3 +449,4 @@ FodyWeavers.xsd
 *.msix
 *.msm
 *.msp
+screenshots-tmp/

--- a/plugins/aks-desktop/.gitignore
+++ b/plugins/aks-desktop/.gitignore
@@ -6,6 +6,7 @@
 out
 dist
 node_modules
+storybook-static
 vsix
 .vscode-test/
 *.vsix

--- a/plugins/aks-desktop/locales/en/translation.json
+++ b/plugins/aks-desktop/locales/en/translation.json
@@ -340,5 +340,6 @@
   "Target CPU Utilization (%)": "Target CPU Utilization (%)",
   "Number of Replicas": "Number of Replicas",
   "Set the desired number of pod replicas for this deployment": "Set the desired number of pod replicas for this deployment",
-  "Save": "Save"
+  "Save": "Save",
+  "namespace: {{namespace}}": "namespace: {{namespace}}"
 }

--- a/plugins/aks-desktop/package-lock.json
+++ b/plugins/aks-desktop/package-lock.json
@@ -17,8 +17,10 @@
       },
       "devDependencies": {
         "@kinvolk/headlamp-plugin": "^0.13.1",
+        "@types/jest-axe": "^3.5.9",
         "@types/react": "^19.2.0",
         "eslint-plugin-no-barrel-files": "^1.2.2",
+        "jest-axe": "^10.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -689,6 +691,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1991,6 +1994,85 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
+      "integrity": "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.2.0.tgz",
+      "integrity": "sha512-1JnRfhqpD8HGpOmQp180Fo9Zt69zNtC+9lR+kT7NVL05tNXIi+QC8Csz7lfidMoVLPD3FnOtcmp0CEFnxExGEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+      "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.2.0.tgz",
+      "integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@joshwooding/vite-plugin-react-docgen-typescript": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/@joshwooding/vite-plugin-react-docgen-typescript/-/vite-plugin-react-docgen-typescript-0.6.1.tgz",
@@ -2233,13 +2315,6 @@
         "csstype": "^3.2.2"
       }
     },
-    "node_modules/@kinvolk/headlamp-plugin/node_modules/@types/use-sync-external-store": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
-      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@kinvolk/headlamp-plugin/node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -2253,46 +2328,6 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@kinvolk/headlamp-plugin/node_modules/react-redux": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
-      "integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.1",
-        "@types/hoist-non-react-statics": "^3.3.1",
-        "@types/use-sync-external-store": "^0.0.3",
-        "hoist-non-react-statics": "^3.3.2",
-        "react-is": "^18.0.0",
-        "use-sync-external-store": "^1.0.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8 || ^17.0 || ^18.0",
-        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
-        "react": "^16.8 || ^17.0 || ^18.0",
-        "react-dom": "^16.8 || ^17.0 || ^18.0",
-        "react-native": ">=0.59",
-        "redux": "^4 || ^5.0.0-beta.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        },
-        "redux": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@kinvolk/headlamp-plugin/node_modules/recharts": {
       "version": "2.15.4",
@@ -3510,6 +3545,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.34.48",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
+      "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
       "dev": true,
       "license": "MIT"
     },
@@ -4817,6 +4859,7 @@
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
       "integrity": "sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hoist-non-react-statics": "^3.3.0"
@@ -4836,6 +4879,100 @@
       "version": "3.27.4",
       "resolved": "https://registry.npmjs.org/@types/humanize-duration/-/humanize-duration-3.27.4.tgz",
       "integrity": "sha512-yaf7kan2Sq0goxpbcwTQ+8E9RP6HutFBPv74T/IA/ojcHKhuKVlk2YFYyHhWZeLvZPzzLE3aatuQB4h0iqyyUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
+      }
+    },
+    "node_modules/@types/jest-axe": {
+      "version": "3.5.9",
+      "resolved": "https://registry.npmjs.org/@types/jest-axe/-/jest-axe-3.5.9.tgz",
+      "integrity": "sha512-z98CzR0yVDalCEuhGXXO4/zN4HHuSebAukXDjTLJyjEAgoUf1H1i+sr7SUB/mz8CRS/03/XChsx0dcLjHkndoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/jest": "*",
+        "axe-core": "^3.5.5"
+      }
+    },
+    "node_modules/@types/jest-axe/node_modules/axe-core": {
+      "version": "3.5.6",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.6.tgz",
+      "integrity": "sha512-LEUDjgmdJoA3LqklSTwKYqkjcZ4HKc4ddIYGSAiSkr46NTjzg2L9RNB+lekO9P7Dlpa87+hBtzc2Fzn/+GUWMQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@types/jest/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@types/jest/node_modules/pretty-format": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
+      "integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
     },
@@ -5039,6 +5176,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/statuses": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
@@ -5067,10 +5211,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
+    },
     "node_modules/@types/wrap-ansi": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
       "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -7156,6 +7323,22 @@
         "node": ">=6.0"
       }
     },
+    "node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cipher-base": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz",
@@ -8123,6 +8306,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/diffie-hellman": {
@@ -9579,6 +9772,24 @@
         "which": "bin/which"
       }
     },
+    "node_modules/expect": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.2.0.tgz",
+      "integrity": "sha512-u/feCi0GPsI+988gU2FLcsHyAHTU0MX1Wg68NhAnN7z/+C5wqG+CY8J53N9ioe8RXgaoz0nBR/TYMf3AycUuPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "30.2.0",
+        "@jest/get-type": "30.1.0",
+        "jest-matcher-utils": "30.2.0",
+        "jest-message-util": "30.2.0",
+        "jest-mock": "30.2.0",
+        "jest-util": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -10669,6 +10880,7 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "react-is": "^16.7.0"
@@ -10678,6 +10890,7 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/html-encoding-sniffer": {
@@ -11889,6 +12102,330 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jest-axe": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/jest-axe/-/jest-axe-10.0.0.tgz",
+      "integrity": "sha512-9QR0M7//o5UVRnEUUm68IsGapHrcKGakYy9dKWWMX79LmeUKguDI6DREyljC5I13j78OUmtKLF5My6ccffLFBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "axe-core": "4.10.2",
+        "chalk": "4.1.2",
+        "jest-matcher-utils": "29.2.2",
+        "lodash.merge": "4.6.2"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
+    },
+    "node_modules/jest-axe/node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-axe/node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-axe/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-axe/node_modules/axe-core": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.2.tgz",
+      "integrity": "sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/jest-axe/node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-axe/node_modules/jest-matcher-utils": {
+      "version": "29.2.2",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.2.2.tgz",
+      "integrity": "sha512-4DkJ1sDPT+UX2MR7Y3od6KtvRi9Im1ZGLGgdLFLm4lPexbTaCgJW5NN3IOXlQHF7NSHY/VHhflQ+WoKtD/vyCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.2.1",
+        "jest-get-type": "^29.2.0",
+        "pretty-format": "^29.2.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-axe/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-axe/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-diff": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.2.0.tgz",
+      "integrity": "sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.0.1",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/pretty-format": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
+      "integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.2.0.tgz",
+      "integrity": "sha512-dQ94Nq4dbzmUWkQ0ANAWS9tBRfqCrn0bV9AMYdOi/MHW726xn7eQmMeRTpX2ViC00bpNaWXq+7o4lIQ3AX13Hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.2.0",
+        "pretty-format": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/pretty-format": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
+      "integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-message-util": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
+      "integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.2.0",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "micromatch": "^4.0.8",
+        "pretty-format": "30.2.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/pretty-format": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
+      "integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-mock": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
+      "integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.2.0",
+        "@types/node": "*",
+        "jest-util": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+      "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
+      "integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.2.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-worker": {
@@ -15121,6 +15658,29 @@
         "react": ">=18"
       }
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -15376,12 +15936,6 @@
         "decimal.js-light": "^2.4.1"
       }
     },
-    "node_modules/recharts/node_modules/@types/use-sync-external-store": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
-      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==",
-      "license": "MIT"
-    },
     "node_modules/recharts/node_modules/immer": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
@@ -15390,51 +15944,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
-      }
-    },
-    "node_modules/recharts/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "license": "MIT"
-    },
-    "node_modules/recharts/node_modules/react-redux": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
-      "integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.1",
-        "@types/hoist-non-react-statics": "^3.3.1",
-        "@types/use-sync-external-store": "^0.0.3",
-        "hoist-non-react-statics": "^3.3.2",
-        "react-is": "^18.0.0",
-        "use-sync-external-store": "^1.0.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8 || ^17.0 || ^18.0",
-        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
-        "react": "^16.8 || ^17.0 || ^18.0",
-        "react-dom": "^16.8 || ^17.0 || ^18.0",
-        "react-native": ">=0.59",
-        "redux": "^4 || ^5.0.0-beta.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        },
-        "redux": {
-          "optional": true
-        }
       }
     },
     "node_modules/rechoir": {
@@ -16422,6 +16931,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/slice-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
@@ -16539,6 +17058,29 @@
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/stackback": {
       "version": "0.0.2",

--- a/plugins/aks-desktop/package.json
+++ b/plugins/aks-desktop/package.json
@@ -41,12 +41,14 @@
   "overrides": {
     "typescript": "5.6.2",
     "react": "^18.3.1",
-    "react-redux": "^8.1.3"
+    "react-redux": "^9.1.0"
   },
   "devDependencies": {
     "@kinvolk/headlamp-plugin": "^0.13.1",
+    "@types/jest-axe": "^3.5.9",
     "@types/react": "^19.2.0",
     "eslint-plugin-no-barrel-files": "^1.2.2",
+    "jest-axe": "^10.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/plugins/aks-desktop/src/components/CreateAKSProject/CreateAKSProject.tsx
+++ b/plugins/aks-desktop/src/components/CreateAKSProject/CreateAKSProject.tsx
@@ -1,564 +1,89 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-import { Icon } from '@iconify/react';
-import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
-import { PageGrid, SectionBox } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
-import { useClustersConf } from '@kinvolk/headlamp-plugin/lib/k8s';
-import { Box, Button, Card, CardContent, CircularProgress, Typography } from '@mui/material';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { useHistory } from 'react-router-dom';
-import {
-  checkNamespaceExists,
-  createManagedNamespace,
-  createNamespaceRoleAssignment,
-  verifyNamespaceAccess,
-} from '../../utils/azure/az-cli';
-import { checkAzureCliAndAksPreview } from '../../utils/azure/checkAzureCli';
 import AzureAuthGuard from '../AzureAuth/AzureAuthGuard';
-import AzureCliWarning from '../AzureCliWarning';
 import { AccessStep } from './components/AccessStep';
 import { BasicsStep } from './components/BasicsStep';
-// Import our new components and hooks
-import { Breadcrumb } from './components/Breadcrumb';
 import { ComputeStep } from './components/ComputeStep';
 import { NetworkingStep } from './components/NetworkingStep';
 import { ReviewStep } from './components/ReviewStep';
-import { useAzureResources } from './hooks/useAzureResources';
-import { useClusterCapabilities } from './hooks/useClusterCapabilities';
-import { useExtensionCheck } from './hooks/useExtensionCheck';
-import { useFeatureCheck } from './hooks/useFeatureCheck';
-import { useFormData } from './hooks/useFormData';
-import { useNamespaceCheck } from './hooks/useNamespaceCheck';
-import { useValidation } from './hooks/useValidation';
-import { mapUIRoleToAzureRole, STEPS } from './types';
-
-const useClusterCheck = ({ cluster }: { cluster?: string }) => {
-  const clustersConf = useClustersConf();
-
-  const isClusterMissing =
-    cluster && Object.values(clustersConf).find((it: any) => it.name === cluster) === undefined;
-
-  return isClusterMissing;
-};
+import CreateAKSProjectPure from './CreateAKSProjectPure';
+import { useCreateAKSProjectWizard } from './hooks/useCreateAKSProjectWizard';
 
 /**
- * Refactored CreateAKSProject component using smaller, testable components
+ * Thin connector for the Create AKS Project wizard.
+ *
+ * Composes {@link useCreateAKSProjectWizard} (all state and async logic) with
+ * {@link CreateAKSProjectPure} (pure presentational rendering). The connector's
+ * only responsibilities are:
+ * - Rendering each step's child component via `renderStepContent`.
+ * - Mapping router actions (`history.push`) to the pure component's callbacks.
+ * - Wrapping the whole page in {@link AzureAuthGuard} to gate authentication.
  */
 function CreateAKSProject() {
   const history = useHistory();
-  const { t } = useTranslation();
-
-  // State management
-  const [activeStep, setActiveStep] = useState(0);
-  const [isCreating, setIsCreating] = useState(false);
-  const [creationProgress, setCreationProgress] = useState('');
-  const [creationError, setCreationError] = useState<string | null>(null);
-  const [showSuccessDialog, setShowSuccessDialog] = useState(false);
-  const [applicationName, setApplicationName] = useState('');
-  const [cliSuggestions, setCliSuggestions] = useState<string[]>([]);
-
-  // Custom hooks
-  const { formData, updateFormData } = useFormData();
-  const azureResources = useAzureResources();
-  const clusterCapabilities = useClusterCapabilities();
-  const extensionStatus = useExtensionCheck();
-  const featureStatus = useFeatureCheck({ subscription: formData.subscription });
-  const namespaceCheck = useNamespaceCheck();
-  const isClusterMissing = useClusterCheck({ cluster: formData.cluster });
-
-  // Validation
-  const validation = useValidation(
-    activeStep,
-    formData,
-    extensionStatus,
-    featureStatus,
-    namespaceCheck,
-    isClusterMissing,
-    clusterCapabilities.capabilities
-  );
-
-  // Fetch subscriptions and check extension/feature on component mount
-  useEffect(() => {
-    azureResources.fetchSubscriptions();
-  }, []);
-
-  // Check Azure CLI and aks-preview extension on component mount
-  useEffect(() => {
-    (async () => {
-      const azureCheck = await checkAzureCliAndAksPreview();
-      console.log('Azure CLI check results:', azureCheck);
-      setCliSuggestions(azureCheck.suggestions);
-    })();
-  }, []);
-
-  // Fetch clusters when subscription changes
-  useEffect(() => {
-    if (formData.subscription) {
-      azureResources.fetchClusters(formData.subscription);
-    } else {
-      azureResources.clearClusters();
-    }
-    // Clear capabilities when subscription changes
-    clusterCapabilities.clearCapabilities();
-  }, [formData.subscription]);
-
-  // Fetch cluster capabilities when cluster selection changes
-  useEffect(() => {
-    if (formData.cluster && formData.subscription && formData.resourceGroup) {
-      clusterCapabilities.fetchCapabilities(
-        formData.subscription,
-        formData.resourceGroup,
-        formData.cluster
-      );
-    } else {
-      clusterCapabilities.clearCapabilities();
-    }
-  }, [formData.cluster, formData.subscription, formData.resourceGroup]);
-
-  // Check namespace existence when project name, cluster, or subscription changes
-  useEffect(() => {
-    const timeoutId = setTimeout(() => {
-      if (
-        formData.projectName &&
-        formData.cluster &&
-        formData.resourceGroup &&
-        formData.subscription
-      ) {
-        namespaceCheck.checkNamespace(
-          formData.cluster,
-          formData.resourceGroup,
-          formData.projectName,
-          formData.subscription
-        );
-      }
-    }, 500); // Debounce the check
-
-    return () => clearTimeout(timeoutId);
-  }, [formData.projectName, formData.cluster, formData.resourceGroup, formData.subscription]);
-  const handleNext = () => {
-    // Clear any existing errors when proceeding
-    azureResources.clearError();
-    azureResources.clearClusterError();
-    setActiveStep(prevStep => prevStep + 1);
-  };
-
-  const handleBack = () => {
-    setActiveStep(prevStep => prevStep - 1);
-  };
-
-  const handleStepClick = (step: number) => {
-    setActiveStep(step);
-  };
-
-  const handleSubmit = async () => {
-    try {
-      console.log('handleSubmit', formData);
-      console.log('Selected cluster details:', {
-        name: formData.cluster,
-        resourceGroup: formData.resourceGroup,
-        subscription: formData.subscription,
-      });
-
-      setIsCreating(true);
-      setCreationError(null);
-      setCreationProgress(`${t('Starting project creation')}...`);
-
-      // Add timeout protection (10 minutes)
-      const timeoutPromise = new Promise((_, reject) => {
-        setTimeout(() => {
-          reject(
-            new Error(
-              t(
-                'Project creation timed out after 10 minutes. Please check if the namespace was created and try again.'
-              )
-            )
-          );
-        }, 10 * 60 * 1000); // 10 minutes
-      });
-
-      // Create the main creation promise
-      const creationPromise = (async () => {
-        // Step 1: Create the managed namespace
-        setCreationProgress(`${t('Initiating managed namespace creation')}...`);
-        const namespaceResult = await createManagedNamespace({
-          clusterName: formData.cluster,
-          resourceGroup: formData.resourceGroup,
-          namespaceName: formData.projectName,
-          subscriptionId: formData.subscription,
-          cpuRequest: formData.cpuRequest,
-          cpuLimit: formData.cpuLimit,
-          memoryRequest: formData.memoryRequest,
-          memoryLimit: formData.memoryLimit,
-          ingressPolicy: formData.ingress,
-          egressPolicy: formData.egress,
-          labels: {
-            'headlamp.dev/project-id': formData.projectName,
-            'headlamp.dev/project-managed-by': 'aks-desktop',
-            'aks-desktop/project-subscription': formData.subscription,
-            'aks-desktop/project-resource-group': formData.resourceGroup,
-          },
-        });
-
-        if (!namespaceResult.success) {
-          throw new Error(
-            t('Namespace creation failed: {{message}}', {
-              message: namespaceResult.error || t('Unknown error'),
-            })
-          );
-        }
-
-        setCreationProgress(`${t('Namespace creation initiated! Monitoring creation status')}...`);
-        console.log('🚀 Namespace creation initiated for:', {
-          cluster: formData.cluster,
-          resourceGroup: formData.resourceGroup,
-          namespace: formData.projectName,
-          subscription: formData.subscription,
-        });
-
-        // Give the namespace a moment to propagate before verification
-        console.log('⏳ Waiting 5 seconds for namespace to propagate...');
-        setCreationProgress(`${t('Waiting for namespace to propagate')}...`);
-        await new Promise(resolve => setTimeout(resolve, 5000));
-
-        // Step 1.5: Monitor namespace creation status with retries
-        let namespaceVerified = false;
-        let retryCount = 0;
-        const maxRetries = 8; // Reduced retries since we have initial delay
-        const retryDelay = 4000; // Increased delay between checks
-
-        while (!namespaceVerified && retryCount < maxRetries) {
-          try {
-            console.log(`🔍 Verification attempt ${retryCount + 1}:`);
-            console.log(`   Cluster: ${formData.cluster}`);
-            console.log(`   Resource Group: ${formData.resourceGroup}`);
-            console.log(`   Namespace: ${formData.projectName}`);
-            console.log(`   Subscription: ${formData.subscription}`);
-
-            // Call the check function directly instead of using the hook
-            const result = await checkNamespaceExists(
-              formData.cluster,
-              formData.resourceGroup,
-              formData.projectName,
-              formData.subscription
-            );
-
-            console.log(`   Direct result exists: ${result.exists}`);
-            console.log(`   Direct result error: ${result.error || 'None'}`);
-
-            if (result.error) {
-              console.log(`   ❌ Namespace check error: ${result.error}`);
-              throw new Error(
-                t('Namespace status check failed: {{message}}', { message: result.error })
-              );
-            }
-
-            if (result.exists === true) {
-              namespaceVerified = true;
-              console.log('✅ Namespace verified successfully');
-            } else {
-              retryCount++;
-              if (retryCount < maxRetries) {
-                console.log(`⏳ Namespace not found yet, retrying in ${retryDelay / 1000}s...`);
-                setCreationProgress(`${t('Waiting for namespace to be created')}...`);
-                await new Promise(resolve => setTimeout(resolve, retryDelay));
-              } else {
-                console.log(`❌ Max retries reached, namespace still not found`);
-              }
-            }
-          } catch (statusError) {
-            console.log(`❌ Verification attempt failed:`, statusError.message);
-            throw new Error(
-              t('Namespace status verification failed: {{message}}', {
-                message: statusError.message,
-              })
-            );
-          }
-        }
-
-        if (!namespaceVerified) {
-          console.log('⚠️ Namespace verification failed, but continuing with creation process...');
-          console.log('   This might be due to timing issues with Azure API propagation.');
-          console.log('   The namespace creation API call succeeded, so we will proceed.');
-          // Don't throw error, just log warning and continue
-          setCreationProgress(
-            `${t('Namespace creation API succeeded, proceeding with user assignments')}...`
-          );
-        }
-
-        setCreationProgress(
-          `${t('Namespace creation completed successfully! Adding user access')}...`
-        );
-
-        // Step 2: Add users to the namespace (only if there are valid assignees)
-        const validAssignments = formData.userAssignments.filter(
-          assignment => assignment.email.trim() !== ''
-        );
-
-        if (validAssignments.length > 0) {
-          setCreationProgress(
-            `${t('Adding user access for {{count}} assignee', {
-              count: validAssignments.length,
-            })}...`
-          );
-
-          const assignmentResults = [];
-          const assignmentErrors = [];
-
-          for (let index = 0; index < validAssignments.length; index++) {
-            const assignment = validAssignments[index];
-            setCreationProgress(`${t('Adding user {{email}}', { email: assignment.email })}...`);
-
-            try {
-              // Map UI role to Azure role name
-              const azureRole = mapUIRoleToAzureRole(assignment.role);
-
-              // Roles to assign: the selected role and the default namespace user role
-              // Note: Platform-specific quoting is handled in createNamespaceRoleAssignment
-              // Namespace contributor is needed to allow users to delete the managed namespace
-              const rolesToAssign = [
-                azureRole,
-                'Azure Kubernetes Service Namespace User',
-                'Azure Kubernetes Service Namespace Contributor',
-              ];
-
-              // Create role assignments for both roles
-              const roleAssignmentResults = [];
-              for (const role of rolesToAssign) {
-                setCreationProgress(
-                  `${t('Assigning {{role}} to {{email}}', {
-                    role,
-                    email: assignment.email,
-                  })}...`
-                );
-
-                const roleResult = await createNamespaceRoleAssignment({
-                  clusterName: formData.cluster,
-                  resourceGroup: formData.resourceGroup,
-                  namespaceName: formData.projectName,
-                  assignee: assignment.email,
-                  role: role,
-                  subscriptionId: formData.subscription,
-                });
-
-                if (!roleResult.success) {
-                  // Capture full error details including stderr which contains Azure CLI error messages
-                  const errorDetails = roleResult.stderr || roleResult.error || t('Unknown error');
-                  roleAssignmentResults.push({
-                    role,
-                    success: false,
-                    error: errorDetails,
-                    errorField: roleResult.error,
-                    stderr: roleResult.stderr,
-                  });
-                } else {
-                  roleAssignmentResults.push({ role, success: true });
-                }
-              }
-
-              // Check if any role assignments failed (excluding skipped ones)
-              // Note: r.role contains the Azure role name (already mapped from UI role)
-              const failedRoles = roleAssignmentResults.filter(r => !r.success && !r.skipped);
-              if (failedRoles.length > 0) {
-                const failedRoleDetails = failedRoles
-                  .map(r => {
-                    // Use stderr if available (contains Azure CLI error), otherwise use error field
-                    // r.role is already the Azure role name (e.g., "Azure Kubernetes Service RBAC Writer")
-                    const errorMsg = r.stderr || r.error || t('Unknown error');
-                    return `${r.role}: ${errorMsg}`;
-                  })
-                  .join('; ');
-                assignmentErrors.push(
-                  t('Failed to assign roles to user {{email}}. {{details}}', {
-                    email: assignment.email,
-                    details: failedRoleDetails,
-                  })
-                );
-                continue;
-              }
-
-              // Verify the user has access
-              setCreationProgress(
-                `${t('Verifying access for user {{email}}', { email: assignment.email })}...`
-              );
-              const verifyResult = await verifyNamespaceAccess({
-                clusterName: formData.cluster,
-                resourceGroup: formData.resourceGroup,
-                namespaceName: formData.projectName,
-                assignee: assignment.email,
-                subscriptionId: formData.subscription,
-              });
-
-              if (!verifyResult.success) {
-                assignmentErrors.push(
-                  t('Failed to verify access for user {{email}}: {{message}}', {
-                    email: assignment.email,
-                    message: verifyResult.error || t('Verification failed'),
-                  })
-                );
-              } else if (!verifyResult.hasAccess) {
-                assignmentErrors.push(
-                  t('User {{email}} does not have the expected access to the namespace', {
-                    email: assignment.email,
-                  })
-                );
-              } else {
-                assignmentResults.push(
-                  '✓ ' + t('User {{email}} added successfully', { email: assignment.email })
-                );
-              }
-            } catch (userError) {
-              assignmentErrors.push(
-                t('Error processing user {{email}}: {{message}}', {
-                  email: assignment.email,
-                  message: userError.message,
-                })
-              );
-            }
-          }
-
-          // Report results
-          if (assignmentErrors.length > 0) {
-            const errorMessage = `${t(
-              'User assignment completed with errors'
-            )}\n${assignmentErrors.join('\n')}`;
-            if (assignmentResults.length > 0) {
-              console.warn('Some user assignments succeeded:', assignmentResults);
-            }
-            throw new Error(errorMessage);
-          }
-        } else {
-          setCreationProgress(`${t('No user assignments to process')}...`);
-        }
-
-        setCreationProgress(t('Project creation completed successfully!'));
-
-        // Final status check - verify the namespace exists and is accessible
-        setCreationProgress(`${t('Performing final status verification')}...`);
-
-        // Final verification with a single retry
-        let finalVerified = false;
-        for (let attempt = 0; attempt < 2 && !finalVerified; attempt++) {
-          try {
-            const result = await checkNamespaceExists(
-              formData.cluster,
-              formData.resourceGroup,
-              formData.projectName,
-              formData.subscription
-            );
-
-            if (result.error) {
-              throw new Error(
-                t('Final status check failed: {{message}}', { message: result.error })
-              );
-            }
-
-            if (result.exists) {
-              finalVerified = true;
-              console.log('✅ Final namespace verification successful');
-            } else if (attempt === 0) {
-              console.log('⏳ Final verification: namespace not found, retrying once...');
-              await new Promise(resolve => setTimeout(resolve, 2000)); // 2 second delay
-            }
-          } catch (finalError) {
-            throw new Error(
-              t('Final status verification failed: {{message}}', {
-                message: finalError.message,
-              })
-            );
-          }
-        }
-
-        if (!finalVerified) {
-          console.log('⚠️ Final verification failed, but namespace creation API succeeded');
-          console.log('   This might be due to timing issues with Azure API propagation.');
-          console.log('   The project creation process will be marked as successful.');
-          // Don't throw error, just log warning and continue
-        }
-
-        setCreationProgress(t('All verifications completed successfully!'));
-      })();
-
-      // Race between creation and timeout
-      await Promise.race([creationPromise, timeoutPromise]);
-
-      // Wait a moment to show success message
-      setTimeout(() => {
-        setIsCreating(false);
-        setShowSuccessDialog(true);
-      }, 2000);
-    } catch (error) {
-      console.error('Error creating AKS project:', error);
-      console.error('Error details:', {
-        message: error.message,
-        stack: error.stack,
-        formData: formData,
-      });
-      setCreationError(error.message || t('Failed to create project'));
-      setIsCreating(false);
-      setCreationProgress(''); // Clear progress message
-    }
-  };
-
-  const onBack = () => {
-    history.push('/');
-  };
+  const wizard = useCreateAKSProjectWizard();
 
   const renderStepContent = (step: number) => {
     const commonProps = {
-      formData,
-      onFormDataChange: updateFormData,
-      validation,
-      loading: azureResources.loading,
-      error: azureResources.error,
+      formData: wizard.formData,
+      onFormDataChange: wizard.updateFormData,
+      validation: wizard.validation,
+      loading: wizard.azureResources.loading,
+      error: wizard.azureResources.error,
     };
-
     switch (step) {
-      case 0: // Basics
+      case 0:
         return (
           <BasicsStep
             {...commonProps}
-            subscriptions={azureResources.subscriptions}
-            clusters={azureResources.clusters}
-            totalClusterCount={azureResources.totalClusterCount}
-            loadingClusters={azureResources.loadingClusters}
-            clusterError={azureResources.clusterError}
-            extensionStatus={extensionStatus}
-            featureStatus={featureStatus}
-            namespaceStatus={namespaceCheck}
-            clusterCapabilities={clusterCapabilities.capabilities}
-            capabilitiesLoading={clusterCapabilities.loading}
-            onInstallExtension={extensionStatus.installExtension}
-            onRegisterFeature={featureStatus.registerFeature}
+            subscriptions={wizard.azureResources.subscriptions}
+            clusters={wizard.azureResources.clusters}
+            totalClusterCount={wizard.azureResources.totalClusterCount}
+            loadingClusters={wizard.azureResources.loadingClusters}
+            clusterError={wizard.azureResources.clusterError}
+            extensionStatus={wizard.extensionStatus}
+            featureStatus={wizard.featureStatus}
+            namespaceStatus={wizard.namespaceCheck}
+            clusterCapabilities={wizard.clusterCapabilities.capabilities}
+            capabilitiesLoading={wizard.clusterCapabilities.loading}
+            onInstallExtension={wizard.extensionStatus.installExtension}
+            onRegisterFeature={wizard.featureStatus.registerFeature}
             onRetrySubscriptions={async () => {
-              await azureResources.fetchSubscriptions();
+              await wizard.azureResources.fetchSubscriptions();
             }}
             onRetryClusters={async () => {
-              await azureResources.fetchClusters(formData.subscription);
+              await wizard.azureResources.fetchClusters(wizard.formData.subscription);
             }}
             onRefreshCapabilities={() => {
-              if (formData.cluster && formData.subscription && formData.resourceGroup) {
-                clusterCapabilities.fetchCapabilities(
-                  formData.subscription,
-                  formData.resourceGroup,
-                  formData.cluster
+              if (
+                wizard.formData.cluster &&
+                wizard.formData.subscription &&
+                wizard.formData.resourceGroup
+              ) {
+                wizard.clusterCapabilities.fetchCapabilities(
+                  wizard.formData.subscription,
+                  wizard.formData.resourceGroup,
+                  wizard.formData.cluster
                 );
               }
             }}
           />
         );
-      case 1: // Networking
+      case 1:
         return <NetworkingStep {...commonProps} />;
-      case 2: // Compute
+      case 2:
         return <ComputeStep {...commonProps} />;
-      case 3: // Access
+      case 3:
         return <AccessStep {...commonProps} />;
-      case 4: // Review
+      case 4:
         return (
           <ReviewStep
             {...commonProps}
-            subscriptions={azureResources.subscriptions}
-            clusters={azureResources.clusters}
+            subscriptions={wizard.azureResources.subscriptions}
+            clusters={wizard.azureResources.clusters}
           />
         );
       default:
@@ -568,302 +93,22 @@ function CreateAKSProject() {
 
   return (
     <AzureAuthGuard>
-      {/** @ts-ignore */}
-      <PageGrid maxWidth="lg" sx={{ margin: '0 auto' }}>
-        <SectionBox
-          title={t('New Project')}
-          subtitle={t('Set up and configure a new project in Azure Kubernetes Service (AKS)')}
-          backLink="/"
-        >
-          {cliSuggestions.length > 0 && (
-            <Box sx={{ mb: 2 }}>
-              <AzureCliWarning suggestions={cliSuggestions} />
-            </Box>
-          )}
-
-          <Card elevation={2} sx={{ position: 'relative' }}>
-            {/* Loading Overlay / Success Screen / Error Display */}
-            {(isCreating || showSuccessDialog || creationError) && (
-              <Box
-                sx={(theme: any) => ({
-                  position: 'absolute',
-                  top: 0,
-                  left: 0,
-                  right: 0,
-                  bottom: 0,
-                  backgroundColor: theme.palette.background.muted,
-                  display: 'flex',
-                  flexDirection: 'column',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  zIndex: 1000,
-                  borderRadius: '4px',
-                })}
-              >
-                {isCreating && !showSuccessDialog && !creationError ? (
-                  // Loading state
-                  <>
-                    <CircularProgress size={60} />
-                    <Typography variant="h6" sx={{ mt: 2, mb: 1 }}>
-                      {t('Creating Project')}...
-                    </Typography>
-                    <Typography
-                      variant="body2"
-                      color="text.secondary"
-                      sx={{ textAlign: 'center', maxWidth: 400, px: 2 }}
-                    >
-                      {creationProgress}
-                    </Typography>
-                  </>
-                ) : creationError ? (
-                  // Error state
-                  <Box
-                    sx={{
-                      textAlign: 'center',
-                      maxWidth: 700,
-                      maxHeight: '70vh',
-                      p: 4,
-                      backgroundColor: 'background.paper',
-                      borderRadius: 2,
-                      boxShadow: 3,
-                      border: '2px solid',
-                      borderColor: 'error.main',
-                      display: 'flex',
-                      flexDirection: 'column',
-                      overflow: 'hidden',
-                    }}
-                  >
-                    {/* Fixed header section */}
-                    <Box sx={{ flexShrink: 0 }}>
-                      <Icon
-                        icon="mdi:alert-circle"
-                        width={64}
-                        height={64}
-                        style={{
-                          marginBottom: 12,
-                          color: 'var(--color-error, #d32f2f)',
-                        }}
-                      />
-                      <Typography
-                        variant="h5"
-                        sx={{ mb: 2, color: 'error.main', fontWeight: 'bold' }}
-                      >
-                        {t('Project Creation Failed')}
-                      </Typography>
-                    </Box>
-                    {/* Scrollable error content */}
-                    <Box
-                      sx={{
-                        flex: 1,
-                        overflowY: 'auto',
-                        mb: 2,
-                        minHeight: '100px',
-                        maxHeight: '400px',
-                      }}
-                    >
-                      <Typography
-                        variant="body2"
-                        sx={{
-                          whiteSpace: 'pre-wrap',
-                          wordWrap: 'break-word',
-                          wordBreak: 'break-word',
-                          overflowWrap: 'break-word',
-                          fontFamily: 'monospace',
-                          fontSize: '0.8rem',
-                          lineHeight: 1.4,
-                          backgroundColor: theme =>
-                            theme.palette.mode === 'dark'
-                              ? 'rgba(211, 47, 47, 0.15)'
-                              : 'rgba(211, 47, 47, 0.08)',
-                          color: 'text.primary',
-                          padding: 2,
-                          borderRadius: 1,
-                          border: '1px solid',
-                          borderColor: theme =>
-                            theme.palette.mode === 'dark'
-                              ? 'rgba(211, 47, 47, 0.5)'
-                              : 'rgba(211, 47, 47, 0.3)',
-                          textAlign: 'left',
-                          width: '100%',
-                          boxSizing: 'border-box',
-                        }}
-                      >
-                        {creationError}
-                      </Typography>
-                    </Box>
-                    {/* Fixed button section */}
-                    <Box sx={{ flexShrink: 0, display: 'flex', gap: 2, justifyContent: 'center' }}>
-                      <Button
-                        variant="outlined"
-                        color="inherit"
-                        onClick={() => {
-                          setCreationError(null);
-                          setCreationProgress('');
-                          onBack();
-                        }}
-                        sx={{ minWidth: 120 }}
-                      >
-                        Cancel
-                      </Button>
-                    </Box>
-                  </Box>
-                ) : showSuccessDialog ? (
-                  // Success state
-                  <Box
-                    sx={{
-                      textAlign: 'center',
-                      maxWidth: 500,
-                      p: 4,
-                      backgroundColor: 'background.paper',
-                      borderRadius: 2,
-                      boxShadow: 3,
-                      border: '1px solid',
-                      borderColor: 'success.main',
-                    }}
-                  >
-                    <Icon
-                      icon="mdi:check-circle"
-                      width={80}
-                      height={80}
-                      color="success.main"
-                      style={{ marginBottom: 16 }}
-                    />
-                    <Typography
-                      variant="h4"
-                      sx={{ mb: 2, color: 'success.main', fontWeight: 'bold' }}
-                    >
-                      {t('Project Created Successfully!')}
-                    </Typography>
-                    <Typography variant="h6" sx={{ mb: 3, color: 'text.secondary' }}>
-                      {t(
-                        'Your AKS project "{{projectName}}" has been created and is ready to use.',
-                        {
-                          projectName: formData.projectName,
-                        }
-                      )}
-                    </Typography>
-                    <Box sx={{ mb: 3 }}>
-                      <input
-                        type="text"
-                        value={applicationName}
-                        onChange={e => setApplicationName(e.target.value)}
-                        placeholder={`${t('Enter application name')}...`}
-                        style={{
-                          width: '100%',
-                          padding: '12px',
-                          border: '1px solid #ccc',
-                          borderRadius: '4px',
-                          marginBottom: '8px',
-                        }}
-                      />
-                      <Typography variant="body2" color="text.secondary" sx={{ textAlign: 'left' }}>
-                        {t(
-                          'Enter a name for your first application to get started with deployment.'
-                        )}
-                      </Typography>
-                    </Box>
-                    <Box sx={{ display: 'flex', gap: 2, justifyContent: 'center' }}>
-                      <Button
-                        variant="outlined"
-                        onClick={() => {
-                          setShowSuccessDialog(false);
-                          onBack();
-                        }}
-                        sx={{ minWidth: 120 }}
-                      >
-                        {t('Cancel')}
-                      </Button>
-                      <Button
-                        variant="contained"
-                        onClick={() => {
-                          if (applicationName.trim()) {
-                            // Navigate to project page with deploy parameters using React Router
-                            const projectName = encodeURIComponent(formData.projectName);
-                            const appName = encodeURIComponent(applicationName.trim());
-                            const projectUrl = `/project/${projectName}?openDeploy=true&applicationName=${appName}`;
-                            console.log('navigating to project page', projectUrl);
-                            history.push(projectUrl);
-                          }
-                        }}
-                        disabled={!applicationName.trim()}
-                        sx={{ minWidth: 180 }}
-                      >
-                        {t('Create Application')}
-                      </Button>
-                    </Box>
-                  </Box>
-                ) : null}
-              </Box>
-            )}
-
-            <CardContent
-              sx={{
-                height: '100%',
-                display: 'flex',
-                flexDirection: 'column',
-                p: 0,
-              }}
-            >
-              {/* Breadcrumbs */}
-              <Breadcrumb
-                steps={STEPS.map(step => t(step))}
-                activeStep={activeStep}
-                onStepClick={handleStepClick}
-              />
-
-              {/* Step Content */}
-              <Box sx={{ p: 3 }}>{renderStepContent(activeStep)}</Box>
-
-              {/* Footer with navigation buttons */}
-              <Box sx={{ p: 3, display: 'flex', alignItems: 'center' }}>
-                {/* Left side - Back and Cancel buttons */}
-                <Box>
-                  {activeStep > 0 && (
-                    <Button variant="contained" color="secondary" onClick={handleBack}>
-                      {t('Back')}
-                    </Button>
-                  )}
-                  {activeStep === 0 && (
-                    <Button variant="contained" color="secondary" onClick={onBack}>
-                      {t('Cancel')}
-                    </Button>
-                  )}
-                </Box>
-
-                {/* Right side - Next/Create Project button */}
-                <Box sx={{ ml: 'auto' }}>
-                  {activeStep === STEPS.length - 1 ? (
-                    <Button
-                      size="large"
-                      variant="contained"
-                      onClick={handleSubmit}
-                      disabled={!validation.isValid}
-                    >
-                      {t('Create Project')}
-                    </Button>
-                  ) : (
-                    <Button
-                      size="large"
-                      variant="contained"
-                      onClick={handleNext}
-                      disabled={azureResources.loading || !validation.isValid}
-                    >
-                      {azureResources.loading ? (
-                        <Box display="flex" alignItems="center" gap={1}>
-                          <CircularProgress size={16} color="inherit" />
-                          {t('Loading')}...
-                        </Box>
-                      ) : (
-                        t('Next')
-                      )}
-                    </Button>
-                  )}
-                </Box>
-              </Box>
-            </CardContent>
-          </Card>
-        </SectionBox>
-      </PageGrid>
+      <CreateAKSProjectPure
+        {...wizard}
+        azureResourcesLoading={wizard.azureResources.loading}
+        projectName={wizard.formData.projectName}
+        onNavigateToProject={url => history.push(url)}
+        onDismissError={() => {
+          wizard.setCreationError(null);
+          wizard.setCreationProgress('');
+          wizard.onBack();
+        }}
+        onCancelSuccess={() => {
+          wizard.setShowSuccessDialog(false);
+          wizard.onBack();
+        }}
+        stepContent={renderStepContent(wizard.activeStep)}
+      />
     </AzureAuthGuard>
   );
 }

--- a/plugins/aks-desktop/src/components/CreateAKSProject/CreateAKSProjectPure.stories.tsx
+++ b/plugins/aks-desktop/src/components/CreateAKSProject/CreateAKSProjectPure.stories.tsx
@@ -1,0 +1,171 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { Meta, StoryFn } from '@storybook/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import CreateAKSProjectPure, { CreateAKSProjectPureProps } from './CreateAKSProjectPure';
+import { STEPS } from './types';
+
+const noOp = () => {};
+const noOpAsync = async () => {};
+
+const baseArgs: CreateAKSProjectPureProps = {
+  activeStep: 0,
+  steps: STEPS,
+  handleNext: noOp,
+  handleBack: noOp,
+  handleStepClick: noOp,
+  handleSubmit: noOpAsync,
+  onBack: noOp,
+  isCreating: false,
+  creationProgress: '',
+  creationError: null,
+  showSuccessDialog: false,
+  applicationName: '',
+  setApplicationName: noOp as any,
+  cliSuggestions: [],
+  validation: { isValid: true },
+  azureResourcesLoading: false,
+  onNavigateToProject: noOp,
+  stepContent: <div>Basics step content</div>,
+  projectName: 'azure-microservices-demo',
+  onDismissError: noOp,
+  onCancelSuccess: noOp,
+};
+
+export default {
+  title: 'CreateAKSProject/CreateAKSProjectPure',
+  component: CreateAKSProjectPure,
+  decorators: [
+    (Story: any) => (
+      <MemoryRouter>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
+} as Meta;
+
+const Template: StoryFn<CreateAKSProjectPureProps> = args => <CreateAKSProjectPure {...args} />;
+
+export const BasicsStepDefault = Template.bind({});
+BasicsStepDefault.args = {
+  ...baseArgs,
+  activeStep: 0,
+  isCreating: false,
+  creationError: null,
+  showSuccessDialog: false,
+  stepContent: <div>Basics step content</div>,
+};
+
+export const LoadingOverlay = Template.bind({});
+LoadingOverlay.args = {
+  ...baseArgs,
+  isCreating: true,
+  creationProgress: 'Creating namespace...',
+};
+
+export const ErrorOverlay = Template.bind({});
+ErrorOverlay.args = {
+  ...baseArgs,
+  isCreating: false,
+  creationError:
+    'Error: Namespace creation failed: ResourceQuotaExceeded — Exceeded quota: compute-resources, requested: limits.cpu=2, used: limits.cpu=14, limited: limits.cpu=14. Failed after 3 retries.',
+};
+
+export const LongErrorMessage = Template.bind({});
+LongErrorMessage.args = {
+  ...baseArgs,
+  isCreating: false,
+  creationError:
+    'Error: Namespace creation failed: ResourceQuotaExceeded — Exceeded quota: compute-resources, requested: limits.cpu=2, used: limits.cpu=14, limited: limits.cpu=14. Failed after 3 retries.\n\nAdditional context: The cluster autoscaler attempted to provision new nodes but all available node pools have reached their maximum size. Node pool "default" is at capacity (10/10 nodes). Node pool "high-memory" is at capacity (5/5 nodes).\n\nRecommended actions:\n  1. Increase the CPU quota for the compute-resources ResourceQuota.\n  2. Scale down existing workloads to free up CPU headroom.\n  3. Request a quota increase from your cluster administrator.\n\nFor more details see: https://docs.example.com/troubleshooting/quota-exceeded',
+};
+
+/**
+ * Error dialog with a very long, realistic multi-phase failure trace.
+ * The error box has `maxHeight: 400px` with `overflowY: auto`, so this
+ * story exercises the scrollable state of the dialog.
+ */
+export const ErrorOverlayScrollable = Template.bind({});
+ErrorOverlayScrollable.args = {
+  ...baseArgs,
+  isCreating: false,
+  creationError: [
+    'Error: Project creation failed after exhausting all retry attempts (attempt 3/3).',
+    '',
+    'Phase 1 — Namespace provisioning:',
+    '  [OK]   Validating namespace name "azure-microservices-demo"',
+    '  [OK]   Checking for existing namespace conflicts',
+    '  [FAIL] Creating namespace: POST https://aks-api-server.eastus.cloudapp.azure.com/api/v1/namespaces',
+    '         Status: 422 Unprocessable Entity',
+    '         Body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure",',
+    '               "message":"namespace \\"azure-microservices-demo\\" is forbidden: exceeded quota: ',
+    '               compute-resources, requested: limits.cpu=4, used: limits.cpu=12, limited: limits.cpu=14",',
+    '               "reason":"Forbidden","details":{"name":"azure-microservices-demo","kind":"namespace"},',
+    '               "code":422}',
+    '',
+    'Phase 2 — RBAC role binding:',
+    '  [SKIP] Skipped due to Phase 1 failure.',
+    '',
+    'Phase 3 — Network policy application:',
+    '  [SKIP] Skipped due to Phase 1 failure.',
+    '',
+    'Phase 4 — Resource quota initialisation:',
+    '  [SKIP] Skipped due to Phase 1 failure.',
+    '',
+    'Retry 1/3 at 2024-06-12T14:03:11Z — same error.',
+    'Retry 2/3 at 2024-06-12T14:03:41Z — same error.',
+    'Retry 3/3 at 2024-06-12T14:04:11Z — same error.',
+    '',
+    'Cluster diagnostics at time of failure:',
+    '  Node pool "system"        : 3/3 nodes Ready, CPU used 78 %, Memory used 61 %',
+    '  Node pool "user-default"  : 5/5 nodes Ready, CPU used 91 %, Memory used 74 %',
+    '  Node pool "high-memory"   : 2/2 nodes Ready, CPU used 43 %, Memory used 88 %',
+    '',
+    'Active ResourceQuotas in namespace "default":',
+    '  compute-resources  limits.cpu=14/14  limits.memory=56Gi/64Gi  pods=47/50',
+    '  storage-resources  requests.storage=480Gi/500Gi',
+    '',
+    'Recommended remediation steps:',
+    '  1. Free up CPU by scaling down or deleting unused Deployments in the "default" namespace.',
+    '  2. Ask your cluster administrator to raise the limits.cpu quota for "default".',
+    '  3. Consider using a dedicated namespace with its own ResourceQuota for this project.',
+    '  4. If autoscaler is enabled, verify node pool max-node-count is not already reached.',
+    '',
+    'Support reference: AKS-ERR-QUOTA-CPU-4421',
+    'Documentation   : https://learn.microsoft.com/azure/aks/operator-best-practices-scheduler',
+  ].join('\n'),
+};
+
+export const ValidationError = Template.bind({});
+ValidationError.args = {
+  ...baseArgs,
+  validation: { isValid: false },
+  azureResourcesLoading: false,
+  stepContent: <div>Basics step content — required fields not filled</div>,
+};
+
+export const SuccessDialog = Template.bind({});
+SuccessDialog.args = {
+  ...baseArgs,
+  showSuccessDialog: true,
+  applicationName: '',
+  projectName: 'my-project',
+};
+
+export const SuccessDialogWithAppName = Template.bind({});
+SuccessDialogWithAppName.args = {
+  ...baseArgs,
+  showSuccessDialog: true,
+  applicationName: 'frontend-service',
+  projectName: 'azure-microservices-demo',
+};
+
+/** "Next" button while Azure resources are loading (`azureResourcesLoading: true`). */
+export const NextButtonLoading = Template.bind({});
+NextButtonLoading.args = {
+  ...baseArgs,
+  azureResourcesLoading: true,
+  validation: { isValid: false },
+  stepContent: <div>Basics step content</div>,
+};

--- a/plugins/aks-desktop/src/components/CreateAKSProject/CreateAKSProjectPure.tsx
+++ b/plugins/aks-desktop/src/components/CreateAKSProject/CreateAKSProjectPure.tsx
@@ -1,0 +1,452 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { Icon } from '@iconify/react';
+import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
+import { PageGrid, SectionBox } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  TextField,
+  Typography,
+} from '@mui/material';
+import React from 'react';
+import AzureCliWarning from '../AzureCliWarning';
+import { Breadcrumb } from './components/Breadcrumb';
+import { STEPS } from './types';
+
+/** Set to `true` locally to enable verbose debug logging. Never enable in production. */
+const DEBUG = false;
+
+/**
+ * Pure presentational props for {@link CreateAKSProjectPure}.
+ * Every value and callback is passed in from the connector — the component
+ * itself has no stateful business-logic hooks (only `useTranslation` for i18n).
+ */
+export interface CreateAKSProjectPureProps {
+  /** Zero-based index of the currently visible wizard step. */
+  activeStep: number;
+  /** Ordered step labels used to render the breadcrumb navigation bar. */
+  steps: typeof STEPS;
+  /** Advances `activeStep` and clears any Azure resource errors. */
+  handleNext: () => void;
+  /** Decrements `activeStep`. */
+  handleBack: () => void;
+  /** Jumps directly to `step`. */
+  handleStepClick: (step: number) => void;
+  /** Kicks off the namespace-creation request. */
+  handleSubmit: () => Promise<void>;
+  /** Navigates back to the home route (`/`). */
+  onBack: () => void;
+  /** `true` while the namespace-creation request is in-flight (shows loading overlay). */
+  isCreating: boolean;
+  /** Status message updated at each stage of the creation process. */
+  creationProgress: string;
+  /** Error message when creation failed; `null` otherwise (shows alertdialog overlay). */
+  creationError: string | null;
+  /** `true` when creation succeeded and the success dialog should be shown. */
+  showSuccessDialog: boolean;
+  /** Name of the first application entered in the success dialog. */
+  applicationName: string;
+  /** Setter for {@link applicationName}. */
+  setApplicationName: React.Dispatch<React.SetStateAction<string>>;
+  /**
+   * CLI warning messages from `checkAzureCliAndAksPreview`.
+   * Non-empty when the Azure CLI or required extensions are missing.
+   */
+  cliSuggestions: string[];
+  /** Per-step validation result; gates the "Next" / "Create Project" button. */
+  validation: { isValid: boolean };
+  /** `true` while Azure subscriptions/clusters are loading; adds `aria-busy` to Next button. */
+  azureResourcesLoading: boolean;
+  /** Navigate to the given URL after the project is created (success dialog). */
+  onNavigateToProject: (url: string) => void;
+  /** Step-specific content rendered inside the scrollable area (composed by the connector). */
+  stepContent: React.ReactNode;
+  /** The project name (`formData.projectName`) shown in success/error dialogs. */
+  projectName: string;
+  /** Dismisses the error alertdialog and navigates back. */
+  onDismissError: () => void;
+  /** Closes the success dialog and navigates back without further action. */
+  onCancelSuccess: () => void;
+}
+
+/**
+ * Pure presentational component for the Create AKS Project wizard.
+ *
+ * Renders the breadcrumb navigation, scrollable step content area, navigation
+ * footer, and the full-screen creation overlays (loading, error alertdialog,
+ * success dialog). All overlays carry complete ARIA attributes for screen
+ * reader accessibility. Contains no stateful business-logic hooks (only `useTranslation`
+ * for i18n) — all state comes from
+ * {@link useCreateAKSProjectWizard} via the connector.
+ *
+ * @see {@link useCreateAKSProjectWizard} for the hook that drives this component.
+ * @see {@link CreateAKSProjectPureProps} for the full prop contract.
+ */
+
+export default function CreateAKSProjectPure({
+  activeStep,
+  steps,
+  handleNext,
+  handleBack,
+  handleStepClick,
+  handleSubmit,
+  onBack,
+  isCreating,
+  creationProgress,
+  creationError,
+  showSuccessDialog,
+  applicationName,
+  setApplicationName,
+  cliSuggestions,
+  validation,
+  azureResourcesLoading,
+  onNavigateToProject,
+  stepContent,
+  projectName,
+  onDismissError,
+  onCancelSuccess,
+}: CreateAKSProjectPureProps) {
+  const { t } = useTranslation();
+
+  return (
+    // @ts-ignore -- headlamp PageGrid typings are incomplete; `sx`/layout props are supported at runtime but not in the type definition.
+    <PageGrid maxWidth="lg" sx={{ margin: '0 auto' }}>
+      <SectionBox
+        title={t('New Project')}
+        subtitle={t('Set up and configure a new project in Azure Kubernetes Service (AKS)')}
+        backLink="/"
+      >
+        {cliSuggestions.length > 0 && (
+          <Box sx={{ mb: 2 }}>
+            <AzureCliWarning suggestions={cliSuggestions} />
+          </Box>
+        )}
+
+        {/* aria-busy signals to assistive technologies that this region is being updated
+            while the project creation request is in-flight. aria-describedby links the Card
+            to the progress indicator so AT knows which region is loading.
+            MDN: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-busy
+            MDN: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby */}
+        <Card
+          elevation={2}
+          sx={{ position: 'relative' }}
+          aria-describedby={isCreating ? 'aksd-create-aks-project-progress' : undefined}
+          aria-busy={isCreating || undefined}
+        >
+          {/* Loading Overlay */}
+          {isCreating && (
+            <Box
+              sx={(theme: any) => ({
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                right: 0,
+                bottom: 0,
+                backgroundColor: theme.palette.background.muted,
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                zIndex: 1000,
+                borderRadius: '4px',
+              })}
+            >
+              {/* id links this progress bar to the Card's aria-describedby above, so assistive
+                  technologies know which region is loading. aria-label provides an accessible
+                  name for the progressbar role since there is no visible text label.
+                  MDN: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/progressbar_role
+                  MUI: https://mui.com/material-ui/react-progress/#accessibility */}
+              <CircularProgress
+                id="aksd-create-aks-project-progress"
+                size={60}
+                aria-label={t('Creating Project')}
+              />
+              <Typography variant="h6" sx={{ mt: 2, mb: 1 }}>
+                {t('Creating Project')}...
+              </Typography>
+              {/* aria-live="polite" causes assistive technologies to announce each status
+                  message update after the current AT output finishes, keeping users informed
+                  of progress without interrupting them.
+                  MDN: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-live */}
+              <Typography
+                aria-live="polite"
+                variant="body2"
+                color="text.secondary"
+                sx={{ textAlign: 'center', maxWidth: 400, px: 2 }}
+              >
+                {creationProgress}
+              </Typography>
+            </Box>
+          )}
+
+          {/* aria-hidden hides the underlying interactive content from assistive technologies
+              while the loading overlay is visible, preventing screen reader users from
+              reaching controls that are visually obscured by the overlay.
+              MDN: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-hidden */}
+          <CardContent
+            aria-hidden={isCreating || undefined}
+            sx={{
+              height: '100%',
+              display: 'flex',
+              flexDirection: 'column',
+              p: 0,
+            }}
+          >
+            {/* Breadcrumbs */}
+            <Breadcrumb
+              steps={steps.map(step => t(step))}
+              activeStep={activeStep}
+              onStepClick={handleStepClick}
+            />
+
+            {/* Step Content */}
+            <Box sx={{ p: 3 }}>{stepContent}</Box>
+
+            {/* Footer with navigation buttons */}
+            <Box sx={{ p: 3, display: 'flex', alignItems: 'center' }}>
+              {/* Left side - Back and Cancel buttons */}
+              <Box>
+                {activeStep > 0 && (
+                  <Button
+                    variant="contained"
+                    color="secondary"
+                    onClick={handleBack}
+                    disabled={isCreating}
+                  >
+                    {t('Back')}
+                  </Button>
+                )}
+                {activeStep === 0 && (
+                  <Button
+                    variant="contained"
+                    color="secondary"
+                    onClick={onBack}
+                    disabled={isCreating}
+                  >
+                    {t('Cancel')}
+                  </Button>
+                )}
+              </Box>
+
+              {/* Right side - Next/Create Project button */}
+              <Box sx={{ ml: 'auto' }}>
+                {activeStep === steps.length - 1 ? (
+                  <Button
+                    size="large"
+                    variant="contained"
+                    onClick={handleSubmit}
+                    disabled={isCreating || !validation.isValid}
+                    aria-busy={isCreating || undefined}
+                  >
+                    {t('Create Project')}
+                  </Button>
+                ) : (
+                  /* aria-busy signals to assistive technologies that the button is performing
+                     an async operation (loading Azure resources). The CircularProgress spinner
+                     is hidden from the accessibility tree with aria-hidden because the button
+                     text ("Loading...") already conveys the busy state to screen readers.
+                     MDN: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-busy
+                     MDN: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-hidden */
+                  <Button
+                    size="large"
+                    variant="contained"
+                    onClick={handleNext}
+                    disabled={azureResourcesLoading || !validation.isValid}
+                    aria-busy={azureResourcesLoading || undefined}
+                  >
+                    {azureResourcesLoading ? (
+                      <Box display="flex" alignItems="center" gap={1}>
+                        <CircularProgress size={16} color="inherit" aria-hidden="true" />
+                        {t('Loading')}...
+                      </Box>
+                    ) : (
+                      t('Next')
+                    )}
+                  </Button>
+                )}
+              </Box>
+            </Box>
+          </CardContent>
+        </Card>
+
+        {/* Success dialog — uses MUI Dialog so focus management and focus trapping
+            are handled automatically, satisfying the role="dialog" accessibility
+            requirements without any custom autoFocus or inert-background logic.
+            MUI: https://mui.com/material-ui/react-dialog/#accessibility */}
+        <Dialog
+          open={showSuccessDialog}
+          onClose={onCancelSuccess}
+          aria-labelledby="aksd-create-aks-project-success-title"
+          aria-describedby="aksd-create-aks-project-success-desc"
+          maxWidth="sm"
+          fullWidth
+          PaperProps={{
+            sx: { border: '1px solid', borderColor: 'success.main', textAlign: 'center' },
+          }}
+        >
+          <DialogTitle
+            id="aksd-create-aks-project-success-title"
+            sx={{ typography: 'h4', color: 'success.main', fontWeight: 'bold', pt: 4 }}
+          >
+            {/* aria-hidden: decorative icon; the adjacent text already names the dialog */}
+            <Icon
+              icon="mdi:check-circle"
+              width={80}
+              height={80}
+              aria-hidden="true"
+              style={{ display: 'block', margin: '0 auto 16px' }}
+            />
+            {t('Project Created Successfully!')}
+          </DialogTitle>
+          <DialogContent>
+            {/* id provides the accessible description for this dialog via aria-describedby.
+                component="p" keeps h6 visual styling but renders as a <p> element so the
+                heading hierarchy (DialogTitle=h2 → this) stays valid. */}
+            <Typography
+              id="aksd-create-aks-project-success-desc"
+              variant="h6"
+              component="p"
+              sx={{ mb: 3, color: 'text.secondary' }}
+            >
+              {t('Your AKS project "{{projectName}}" has been created and is ready to use.', {
+                projectName,
+              })}
+            </Typography>
+            {/* MUI TextField manages the label–input association via htmlFor/id automatically.
+                MUI: https://mui.com/material-ui/react-text-field/#accessibility
+                autoFocus moves keyboard focus into the dialog when it opens. MUI Dialog handles
+                focus trapping; autoFocus on the first interactive element ensures keyboard and
+                screen reader users land on the input immediately without extra navigation.
+                MUI: https://mui.com/material-ui/react-dialog/#accessibility */}
+            <TextField
+              label={t('Application name')}
+              fullWidth
+              // eslint-disable-next-line jsx-a11y/no-autofocus
+              autoFocus
+              value={applicationName}
+              onChange={e => setApplicationName(e.target.value)}
+              placeholder={`${t('Enter application name')}...`}
+              helperText={t(
+                'Enter a name for your first application to get started with deployment.'
+              )}
+            />
+          </DialogContent>
+          <DialogActions sx={{ px: 3, pb: 2 }}>
+            <Button variant="outlined" onClick={onCancelSuccess}>
+              {t('Cancel')}
+            </Button>
+            <Button
+              variant="contained"
+              onClick={() => {
+                if (applicationName.trim()) {
+                  const encodedProject = encodeURIComponent(projectName);
+                  const appName = encodeURIComponent(applicationName.trim());
+                  const projectUrl = `/project/${encodedProject}?openDeploy=true&applicationName=${appName}`;
+                  if (DEBUG) console.log('navigating to project page', projectUrl);
+                  onNavigateToProject(projectUrl);
+                }
+              }}
+              disabled={!applicationName.trim()}
+            >
+              {t('Create Application')}
+            </Button>
+          </DialogActions>
+        </Dialog>
+
+        {/* Error Dialog — role="alertdialog" because the user must interact with the
+            Cancel button to dismiss it. MUI Dialog provides built-in focus trapping,
+            focus management, and aria-modal handling automatically.
+            role is set via PaperProps so it lands on the same Paper element that MUI
+            puts aria-labelledby on; if set on the Dialog root prop it goes to the
+            outer MuiModal-root div which has no aria-labelledby (axe: aria-dialog-name).
+            MDN: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/alertdialog_role
+            MUI: https://mui.com/material-ui/react-dialog/#accessibility */}
+        <Dialog
+          open={!!creationError}
+          onClose={onDismissError}
+          aria-labelledby="aksd-create-aks-project-error-title"
+          aria-describedby="aksd-create-aks-project-error-desc"
+          maxWidth="md"
+          fullWidth
+          PaperProps={{
+            role: 'alertdialog',
+            sx: {
+              border: '2px solid',
+              borderColor: 'error.main',
+              textAlign: 'center',
+              maxWidth: 700,
+            },
+          }}
+        >
+          <DialogTitle
+            id="aksd-create-aks-project-error-title"
+            sx={{ typography: 'h5', color: 'error.main', fontWeight: 'bold', pt: 4 }}
+          >
+            {/* aria-hidden: decorative icon; the adjacent text already names the dialog */}
+            <Icon
+              icon="mdi:alert-circle"
+              width={64}
+              height={64}
+              aria-hidden="true"
+              style={{ display: 'block', margin: '0 auto 12px' }}
+            />
+            {t('Project Creation Failed')}
+          </DialogTitle>
+          <DialogContent sx={{ maxHeight: '400px', overflowY: 'auto' }}>
+            {/* id provides the accessible description for this alertdialog via aria-describedby */}
+            <Typography
+              id="aksd-create-aks-project-error-desc"
+              variant="body2"
+              sx={{
+                whiteSpace: 'pre-wrap',
+                overflowWrap: 'break-word',
+                fontFamily: 'monospace',
+                fontSize: '0.8rem',
+                lineHeight: 1.4,
+                backgroundColor: theme =>
+                  theme.palette.mode === 'dark'
+                    ? 'rgba(211, 47, 47, 0.15)'
+                    : 'rgba(211, 47, 47, 0.08)',
+                color: 'text.primary',
+                padding: 2,
+                borderRadius: 1,
+                border: '1px solid',
+                borderColor: theme =>
+                  theme.palette.mode === 'dark'
+                    ? 'rgba(211, 47, 47, 0.5)'
+                    : 'rgba(211, 47, 47, 0.3)',
+              }}
+            >
+              {creationError}
+            </Typography>
+          </DialogContent>
+          <DialogActions sx={{ justifyContent: 'center', pb: 2 }}>
+            {/* autoFocus moves keyboard focus to Cancel when the alertdialog opens, satisfying
+                the MDN requirement that focus lands on the dismiss control immediately.
+                MUI Dialog handles focus trapping; autoFocus ensures the correct initial target.
+                MDN: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/alertdialog_role */}
+            <Button
+              // eslint-disable-next-line jsx-a11y/no-autofocus
+              autoFocus
+              variant="outlined"
+              color="inherit"
+              onClick={onDismissError}
+              sx={{ minWidth: 120 }}
+            >
+              {t('Cancel')}
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </SectionBox>
+    </PageGrid>
+  );
+}

--- a/plugins/aks-desktop/src/components/CreateAKSProject/__tests__/CreateAKSProjectPure.a11y.test.tsx
+++ b/plugins/aks-desktop/src/components/CreateAKSProject/__tests__/CreateAKSProjectPure.a11y.test.tsx
@@ -1,0 +1,155 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+// @vitest-environment jsdom
+import { cleanup, render } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+expect.extend(toHaveNoViolations);
+
+// ── module mocks ─────────────────────────────────────────────────────────────
+// Use a real i18next instance so {{variable}} interpolation works correctly in
+// rendered output (e.g. 'Your AKS project "{{projectName}}"...' → 'Your AKS
+// project "my-project"...'). react-i18next falls back to the global i18next
+// instance set by initReactI18next, so no I18nextProvider wrapper is needed.
+vi.mock('@kinvolk/headlamp-plugin/lib', async () => {
+  const i18n = (await import('i18next')).default;
+  const { initReactI18next, useTranslation } = await import('react-i18next');
+  if (!i18n.isInitialized) {
+    await i18n.use(initReactI18next).init({
+      lng: 'en',
+      fallbackLng: 'en',
+      resources: { en: { translation: {} } },
+      interpolation: { escapeValue: false },
+      returnEmptyString: false,
+    });
+  }
+  return { useTranslation };
+});
+
+vi.mock('@kinvolk/headlamp-plugin/lib/CommonComponents', () => ({
+  PageGrid: ({ children }: any) => <div>{children}</div>,
+  SectionBox: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock('@iconify/react', () => ({
+  Icon: ({ icon }: any) => <span data-icon={icon} aria-hidden="true" />,
+}));
+
+// ── component under test ─────────────────────────────────────────────────────
+import CreateAKSProjectPure, { CreateAKSProjectPureProps } from '../CreateAKSProjectPure';
+import { STEPS } from '../types';
+
+afterEach(() => cleanup());
+
+const noOp = () => {};
+const baseArgs: CreateAKSProjectPureProps = {
+  activeStep: 0,
+  steps: STEPS,
+  handleNext: noOp,
+  handleBack: noOp,
+  handleStepClick: noOp,
+  handleSubmit: async () => {},
+  onBack: noOp,
+  isCreating: false,
+  creationProgress: '',
+  creationError: null,
+  showSuccessDialog: false,
+  applicationName: '',
+  setApplicationName: noOp as any,
+  cliSuggestions: [],
+  validation: { isValid: true },
+  azureResourcesLoading: false,
+  onNavigateToProject: noOp,
+  stepContent: <div>Basics step content</div>,
+  projectName: 'my-project',
+  onDismissError: noOp,
+  onCancelSuccess: noOp,
+};
+
+function renderInRouter(props: CreateAKSProjectPureProps) {
+  return render(
+    <MemoryRouter>
+      <CreateAKSProjectPure {...props} />
+    </MemoryRouter>
+  );
+}
+
+// Component-level tests scan document.body so MUI Dialog portal content is
+// included. The 'region' rule requires every element to be inside a landmark,
+// which only makes sense for full-page tests, not isolated component tests.
+const axeConfig = { rules: { region: { enabled: false } } };
+
+describe('CreateAKSProjectPure a11y', () => {
+  test('BasicsStepDefault has no violations', async () => {
+    renderInRouter({ ...baseArgs });
+    expect(await axe(document.body, axeConfig)).toHaveNoViolations();
+  });
+
+  test('LoadingOverlay has no violations', async () => {
+    renderInRouter({
+      ...baseArgs,
+      isCreating: true,
+      creationProgress: 'Creating namespace...',
+    });
+    expect(await axe(document.body, axeConfig)).toHaveNoViolations();
+  });
+
+  test('ErrorOverlay has no violations', async () => {
+    renderInRouter({
+      ...baseArgs,
+      creationError: 'Error: Namespace creation failed: quota exceeded',
+    });
+    expect(await axe(document.body, axeConfig)).toHaveNoViolations();
+  });
+
+  test('SuccessDialog has no violations', async () => {
+    renderInRouter({
+      ...baseArgs,
+      showSuccessDialog: true,
+      applicationName: '',
+      projectName: 'my-project',
+    });
+    expect(await axe(document.body, axeConfig)).toHaveNoViolations();
+  });
+
+  test('SuccessDialog with app name has no violations', async () => {
+    renderInRouter({
+      ...baseArgs,
+      showSuccessDialog: true,
+      applicationName: 'frontend-app',
+      projectName: 'my-project',
+    });
+    expect(await axe(document.body, axeConfig)).toHaveNoViolations();
+  });
+
+  test('NextButtonLoading has no violations', async () => {
+    renderInRouter({
+      ...baseArgs,
+      azureResourcesLoading: true,
+      validation: { isValid: false },
+    });
+    expect(await axe(document.body, axeConfig)).toHaveNoViolations();
+  });
+
+  test('LongErrorMessage has no violations', async () => {
+    renderInRouter({
+      ...baseArgs,
+      creationError:
+        'Error: Namespace creation failed: ResourceQuotaExceeded — Exceeded quota: compute-resources, requested: limits.cpu=2, used: limits.cpu=14, limited: limits.cpu=14. Failed after 3 retries.\n\nAdditional context: The cluster autoscaler attempted to provision new nodes but all available node pools have reached their maximum size. Node pool "default" is at capacity (10/10 nodes). Node pool "high-memory" is at capacity (5/5 nodes).\n\nRecommended actions:\n  1. Increase the CPU quota for the compute-resources ResourceQuota.\n  2. Scale down existing workloads to free up CPU headroom.\n  3. Request a quota increase from your cluster administrator.',
+    });
+    expect(await axe(document.body, axeConfig)).toHaveNoViolations();
+  });
+
+  test('ValidationError state has no violations', async () => {
+    renderInRouter({
+      ...baseArgs,
+      validation: { isValid: false },
+      azureResourcesLoading: false,
+    });
+    expect(await axe(document.body, axeConfig)).toHaveNoViolations();
+  });
+});

--- a/plugins/aks-desktop/src/components/CreateAKSProject/__tests__/CreateAKSProjectPure.test.tsx
+++ b/plugins/aks-desktop/src/components/CreateAKSProject/__tests__/CreateAKSProjectPure.test.tsx
@@ -1,0 +1,258 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+// @vitest-environment jsdom
+/**
+ * Interaction tests for {@link CreateAKSProjectPure}.
+ *
+ * Each test renders the component using the args from the corresponding
+ * Storybook story so that the stories act as a single source of truth for
+ * both the visual catalogue and the interaction test matrix.
+ *
+ * Pattern:
+ *   1. Import story args.
+ *   2. Spy on every callback prop.
+ *   3. Render via RTL.
+ *   4. Simulate user gestures.
+ *   5. Assert the correct callback fired.
+ */
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// ── module mocks ─────────────────────────────────────────────────────────────
+vi.mock('@kinvolk/headlamp-plugin/lib', async () => {
+  const i18n = (await import('i18next')).default;
+  const { initReactI18next, useTranslation } = await import('react-i18next');
+  if (!i18n.isInitialized) {
+    await i18n.use(initReactI18next).init({
+      lng: 'en',
+      fallbackLng: 'en',
+      resources: { en: { translation: {} } },
+      interpolation: { escapeValue: false },
+      returnEmptyString: false,
+    });
+  }
+  return { useTranslation };
+});
+
+vi.mock('@kinvolk/headlamp-plugin/lib/CommonComponents', () => ({
+  PageGrid: ({ children }: any) => <div>{children}</div>,
+  SectionBox: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock('@iconify/react', () => ({
+  Icon: ({ icon }: any) => <span data-icon={icon} aria-hidden="true" />,
+}));
+
+// ── component + stories ───────────────────────────────────────────────────────
+import CreateAKSProjectPure, { CreateAKSProjectPureProps } from '../CreateAKSProjectPure';
+import {
+  BasicsStepDefault,
+  ErrorOverlay,
+  LoadingOverlay,
+  NextButtonLoading,
+  SuccessDialog,
+  SuccessDialogWithAppName,
+  ValidationError,
+} from '../CreateAKSProjectPure.stories';
+
+afterEach(() => cleanup());
+
+/** Render a story using its args, overriding callbacks with jest spies. */
+function renderStory(
+  storyArgs: CreateAKSProjectPureProps,
+  overrides: Partial<CreateAKSProjectPureProps> = {}
+) {
+  const props: CreateAKSProjectPureProps = { ...storyArgs, ...overrides };
+  return render(
+    <MemoryRouter>
+      <CreateAKSProjectPure {...props} />
+    </MemoryRouter>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('CreateAKSProjectPure — BasicsStepDefault story interactions', () => {
+  it('renders the step content provided by the story', () => {
+    renderStory(BasicsStepDefault.args!);
+    expect(screen.getByText('Basics step content')).toBeInTheDocument();
+  });
+
+  it('calls onBack when Cancel button is clicked on step 0', () => {
+    const onBack = vi.fn();
+    renderStory(BasicsStepDefault.args!, { onBack });
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls handleNext when Next button is clicked', () => {
+    const handleNext = vi.fn();
+    renderStory(BasicsStepDefault.args!, { handleNext });
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+    expect(handleNext).toHaveBeenCalledTimes(1);
+  });
+
+  it('Next button is enabled when validation.isValid is true', () => {
+    renderStory(BasicsStepDefault.args!, { validation: { isValid: true } });
+    expect(screen.getByRole('button', { name: /next/i })).not.toBeDisabled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('CreateAKSProjectPure — ValidationError story interactions', () => {
+  it('Next button is disabled when validation.isValid is false', () => {
+    renderStory(ValidationError.args!);
+    expect(screen.getByRole('button', { name: /next/i })).toBeDisabled();
+  });
+
+  it('does not call handleNext when Next is clicked while disabled', () => {
+    const handleNext = vi.fn();
+    renderStory(ValidationError.args!, { handleNext });
+    // fireEvent.click still fires the DOM event; the button's disabled attribute
+    // prevents the onClick handler from being called by React.
+    const btn = screen.getByRole('button', { name: /next/i });
+    expect(btn).toBeDisabled();
+    fireEvent.click(btn);
+    expect(handleNext).not.toHaveBeenCalled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('CreateAKSProjectPure — NextButtonLoading story interactions', () => {
+  it('Next button is disabled while Azure resources are loading', () => {
+    renderStory(NextButtonLoading.args!);
+    expect(screen.getByRole('button', { name: /loading/i })).toBeDisabled();
+  });
+
+  it('Next button shows loading text while azureResourcesLoading', () => {
+    renderStory(NextButtonLoading.args!);
+    expect(screen.getByRole('button', { name: /loading/i })).toBeInTheDocument();
+  });
+
+  it('does not call handleNext while loading', () => {
+    const handleNext = vi.fn();
+    renderStory(NextButtonLoading.args!, { handleNext });
+    const btn = screen.getByRole('button', { name: /loading/i });
+    fireEvent.click(btn);
+    expect(handleNext).not.toHaveBeenCalled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('CreateAKSProjectPure — LoadingOverlay story interactions', () => {
+  it('renders the loading progress text', () => {
+    renderStory(LoadingOverlay.args!);
+    expect(screen.getByText(/creating namespace/i)).toBeInTheDocument();
+  });
+
+  it('Create Project button is absent during loading (last step not rendered in overlay)', () => {
+    // During loading the overlay replaces step content; the Create Project button
+    // on the last step is disabled while isCreating is true.
+    renderStory(LoadingOverlay.args!);
+    // On step 0 Next is rendered but disabled while isCreating + !validation.isValid
+    const btn = screen.queryByRole('button', { name: /create project/i });
+    if (btn) expect(btn).toBeDisabled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('CreateAKSProjectPure — ErrorOverlay story interactions', () => {
+  it('renders the error message from the story', () => {
+    renderStory(ErrorOverlay.args!);
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+    expect(screen.getByText(/namespace creation failed/i)).toBeInTheDocument();
+  });
+
+  it('calls onDismissError when Cancel in the error dialog is clicked', () => {
+    const onDismissError = vi.fn();
+    renderStory(ErrorOverlay.args!, { onDismissError });
+    // The alertdialog has a Cancel button; there may be other Cancel buttons too.
+    const dialog = screen.getByRole('alertdialog');
+    const cancelBtn = within(dialog).getByRole('button', { name: /cancel/i });
+    fireEvent.click(cancelBtn);
+    expect(onDismissError).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onCancelSuccess when error dialog Cancel is clicked', () => {
+    const onCancelSuccess = vi.fn();
+    const onDismissError = vi.fn();
+    renderStory(ErrorOverlay.args!, { onCancelSuccess, onDismissError });
+    const dialog = screen.getByRole('alertdialog');
+    fireEvent.click(within(dialog).getByRole('button', { name: /cancel/i }));
+    expect(onCancelSuccess).not.toHaveBeenCalled();
+  });
+
+  it('error dialog has the correct accessible title', () => {
+    renderStory(ErrorOverlay.args!);
+    expect(screen.getByRole('heading', { name: /project creation failed/i })).toBeInTheDocument();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('CreateAKSProjectPure — SuccessDialog story interactions', () => {
+  it('renders the success dialog', () => {
+    renderStory(SuccessDialog.args!);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('calls onCancelSuccess when Cancel button is clicked in success dialog', () => {
+    const onCancelSuccess = vi.fn();
+    renderStory(SuccessDialog.args!, { onCancelSuccess });
+    const dialog = screen.getByRole('dialog');
+    fireEvent.click(within(dialog).getByRole('button', { name: /cancel/i }));
+    expect(onCancelSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('Create Application button is disabled when application name is empty', () => {
+    renderStory(SuccessDialog.args!, { applicationName: '' });
+    expect(screen.getByRole('button', { name: /create application/i })).toBeDisabled();
+  });
+
+  it('Create Application button is enabled when application name is provided', () => {
+    renderStory(SuccessDialog.args!, { applicationName: 'my-app' });
+    expect(screen.getByRole('button', { name: /create application/i })).not.toBeDisabled();
+  });
+
+  it('calls onNavigateToProject with encoded URL when Create Application is clicked', () => {
+    const onNavigateToProject = vi.fn();
+    renderStory(SuccessDialog.args!, {
+      applicationName: 'my-app',
+      projectName: 'my-project',
+      onNavigateToProject,
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create application/i }));
+    expect(onNavigateToProject).toHaveBeenCalledTimes(1);
+    const [url] = onNavigateToProject.mock.calls[0];
+    expect(url).toContain('/project/my-project');
+    expect(url).toContain('openDeploy=true');
+    expect(url).toContain('applicationName=my-app');
+  });
+
+  it('updates application name when typed into the text field', () => {
+    const setApplicationName = vi.fn();
+    renderStory(SuccessDialog.args!, { setApplicationName });
+    const input = screen.getByRole('textbox', { name: /application name/i });
+    fireEvent.change(input, { target: { value: 'new-service' } });
+    expect(setApplicationName).toHaveBeenCalled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('CreateAKSProjectPure — SuccessDialogWithAppName story interactions', () => {
+  it('Create Application button is enabled when story provides an application name', () => {
+    renderStory(SuccessDialogWithAppName.args!);
+    expect(screen.getByRole('button', { name: /create application/i })).not.toBeDisabled();
+  });
+
+  it('calls onNavigateToProject with the story application name', () => {
+    const onNavigateToProject = vi.fn();
+    renderStory(SuccessDialogWithAppName.args!, { onNavigateToProject });
+    fireEvent.click(screen.getByRole('button', { name: /create application/i }));
+    expect(onNavigateToProject).toHaveBeenCalledTimes(1);
+    const [url] = onNavigateToProject.mock.calls[0];
+    expect(url).toContain('applicationName=frontend-service');
+  });
+});

--- a/plugins/aks-desktop/src/components/CreateAKSProject/components/BasicsStep.tsx
+++ b/plugins/aks-desktop/src/components/CreateAKSProject/components/BasicsStep.tsx
@@ -23,6 +23,9 @@ import { FormField } from './FormField';
 import { SearchableSelect, SearchableSelectOption } from './SearchableSelect';
 import { ValidationAlert } from './ValidationAlert';
 
+/** Set to `true` locally to enable verbose debug logging. Never enable in production. */
+const DEBUG = false;
+
 // Helper to check if there are addons that can be enabled post-creation
 const hasConfigurableAddons = (cap: ClusterCapabilities | null): boolean => {
   if (!cap) return false;
@@ -201,15 +204,21 @@ export const BasicsStep: React.FC<BasicsStepProps> = ({
             </Box>
           }
           action={
+            /* aria-busy signals to AT that this button is performing an async operation.
+               The CircularProgress spinner is hidden with aria-hidden because the button
+               text ("Installing...") already conveys the busy state to screen readers.
+               MDN: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-busy
+               MDN: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-hidden */
             <Button
               color="inherit"
               size="small"
               onClick={onInstallExtension}
               disabled={extensionStatus.installing}
+              aria-busy={extensionStatus.installing || undefined}
             >
               {extensionStatus.installing ? (
                 <Box display="flex" alignItems="center" gap={1}>
-                  <CircularProgress size={16} color="inherit" />
+                  <CircularProgress size={16} color="inherit" aria-hidden="true" />
                   {`${t('Installing')}...`}
                 </Box>
               ) : (
@@ -250,17 +259,21 @@ export const BasicsStep: React.FC<BasicsStepProps> = ({
                   {featureStatus.error}
                 </Typography>
               )}
-
+              /* Same aria-busy + aria-hidden pattern: button text ("Registering...") conveys the
+              busy state, so the spinner is decorative and hidden from AT. MDN:
+              https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-busy
+              */
               <Button
                 variant="contained"
                 onClick={onRegisterFeature}
                 disabled={featureStatus.registering}
                 sx={{ alignSelf: 'flex-start' }}
                 size="large"
+                aria-busy={featureStatus.registering || undefined}
               >
                 {featureStatus.registering ? (
                   <Box display="flex" alignItems="center" gap={1}>
-                    <CircularProgress size={16} color="inherit" />
+                    <CircularProgress size={16} color="inherit" aria-hidden="true" />
                     {t('Registering')}...
                   </Box>
                 ) : (
@@ -401,15 +414,19 @@ export const BasicsStep: React.FC<BasicsStepProps> = ({
                     }
                     // refresh button to reload clusters
                     action={
+                      /* Same aria-busy + aria-hidden pattern: button text ("Refreshing...") conveys
+                         the busy state, so the spinner is decorative and hidden from AT.
+                         MDN: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-busy */
                       <Button
                         color="inherit"
                         size="small"
                         onClick={onRetryClusters}
                         disabled={loadingClusters}
+                        aria-busy={loadingClusters || undefined}
                       >
                         {loadingClusters ? (
                           <Box display="flex" alignItems="center" gap={1}>
-                            <CircularProgress size={16} color="inherit" />
+                            <CircularProgress size={16} color="inherit" aria-hidden="true" />
                             {t('Refreshing')}...
                           </Box>
                         ) : (
@@ -500,17 +517,16 @@ function RegisterCluster({
     setSuccess(undefined);
 
     try {
-      // Register the cluster by running az aks get-credentials and setting up kubeconfig
-      console.log('[AKS] Registering cluster...');
+      if (DEBUG) console.log('[AKS] Registering cluster...');
       const result = await registerAKSCluster(subscription, resourceGroup, cluster);
-      console.log('[AKS] Register cluster result:', result);
+      if (DEBUG) console.log('[AKS] Register cluster result:', result.success);
       if (!result.success) {
         setError(result.message);
         setLoading(false);
         return;
       }
 
-      console.log('[AKS] Cluster registered successfully:', result.message);
+      if (DEBUG) console.log('[AKS] Cluster registered successfully.');
       setSuccess(t("Cluster '{{cluster}}' successfully merged in kubeconfig", { cluster }));
       setLoading(false);
     } catch (err) {
@@ -551,11 +567,15 @@ function RegisterCluster({
 
       {/* Hide button when success is shown */}
       {!success && (
+        /* Same aria-busy + aria-hidden pattern: button text ("Registering cluster...") conveys
+           the busy state, so the spinner is decorative and hidden from AT.
+           MDN: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-busy */
         <Button
           onClick={handleRegister}
           variant="contained"
-          startIcon={loading ? <CircularProgress /> : <Icon icon="mdi:plus" />}
+          startIcon={loading ? <CircularProgress aria-hidden="true" /> : <Icon icon="mdi:plus" />}
           disabled={loading}
+          aria-busy={loading || undefined}
         >
           {loading ? `${t('Registering cluster')}...` : t('Register Cluster')}
         </Button>

--- a/plugins/aks-desktop/src/components/CreateAKSProject/components/ClusterConfigurePanel.tsx
+++ b/plugins/aks-desktop/src/components/CreateAKSProject/components/ClusterConfigurePanel.tsx
@@ -318,8 +318,12 @@ export const ClusterConfigurePanel: React.FC<ClusterConfigurePanelProps> = ({
 
       {/* Polling progress */}
       {polling && (
-        <Box display="flex" alignItems="center" gap={1} sx={{ mt: 1 }}>
-          <CircularProgress size={16} />
+        /* role="status" causes assistive technologies to announce the "Configuring cluster"
+           message when this Box is dynamically inserted into the DOM (polite live region).
+           The CircularProgress spinner is decorative and hidden from AT with aria-hidden.
+           MDN: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/status_role */
+        <Box role="status" display="flex" alignItems="center" gap={1} sx={{ mt: 1 }}>
+          <CircularProgress size={16} aria-hidden="true" />
           <Typography variant="body2" color="text.secondary">
             Configuring cluster... This may take a few minutes.
           </Typography>
@@ -328,12 +332,19 @@ export const ClusterConfigurePanel: React.FC<ClusterConfigurePanelProps> = ({
 
       {/* Configure button */}
       {!success && (
+        /* aria-busy signals to AT that the button is performing an async operation.
+           The CircularProgress spinner is decorative and hidden from AT with aria-hidden
+           because the button text ("Enabling Addons...") already conveys the busy state.
+           MDN: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-busy */
         <Button
           variant="contained"
           onClick={handleConfigure}
           disabled={enabling || polling || selectedAddons.size === 0}
           sx={{ mt: 2 }}
-          startIcon={enabling ? <CircularProgress size={16} color="inherit" /> : undefined}
+          aria-busy={enabling || polling || undefined}
+          startIcon={
+            enabling ? <CircularProgress size={16} color="inherit" aria-hidden="true" /> : undefined
+          }
         >
           {enabling ? 'Enabling Addons...' : polling ? 'Configuring...' : 'Configure Cluster'}
         </Button>

--- a/plugins/aks-desktop/src/components/CreateAKSProject/components/SearchableSelect.tsx
+++ b/plugins/aks-desktop/src/components/CreateAKSProject/components/SearchableSelect.tsx
@@ -70,7 +70,11 @@ export const SearchableSelect: React.FC<SearchableSelectProps> = ({
             ...params.InputProps,
             endAdornment: (
               <>
-                {loading ? <CircularProgress color="inherit" size={20} /> : null}
+                {/* The adornment spinner is decorative; MUI Autocomplete already manages
+                    aria-busy on the listbox via the loading prop, so this spinner
+                    would cause a duplicate announcement if not hidden.
+                    MUI: https://mui.com/material-ui/react-autocomplete/#asynchronous-requests */}
+                {loading ? <CircularProgress color="inherit" size={20} aria-hidden="true" /> : null}
                 {params.InputProps.endAdornment}
               </>
             ),

--- a/plugins/aks-desktop/src/components/CreateAKSProject/components/__tests__/ClusterConfigurePanel.test.tsx
+++ b/plugins/aks-desktop/src/components/CreateAKSProject/components/__tests__/ClusterConfigurePanel.test.tsx
@@ -184,8 +184,8 @@ describe('ClusterConfigurePanel', () => {
       expect(configuringMessages.length).toBeGreaterThan(0);
     });
 
-    // Should show a progress indicator (CircularProgress renders role="progressbar")
-    expect(screen.getAllByRole('progressbar').length).toBeGreaterThan(0);
+    // Should show the status container that announces the loading state to screen readers
+    expect(screen.getByRole('status')).toBeTruthy();
   });
 
   test('calls onConfigured callback after successful configuration and polling', async () => {

--- a/plugins/aks-desktop/src/components/CreateAKSProject/hooks/useCreateAKSProjectWizard.test.ts
+++ b/plugins/aks-desktop/src/components/CreateAKSProject/hooks/useCreateAKSProjectWizard.test.ts
@@ -1,0 +1,235 @@
+// @vitest-environment jsdom
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Use a real i18next instance so {{variable}} interpolation works correctly in
+// error messages (e.g. 'Namespace status verification failed: {{message}}'
+// renders with the actual message instead of the raw placeholder).
+// react-i18next falls back to the global instance set by initReactI18next, so
+// no I18nextProvider wrapper is needed.
+vi.mock('@kinvolk/headlamp-plugin/lib', async () => {
+  const i18n = (await import('i18next')).default;
+  const { initReactI18next, useTranslation } = await import('react-i18next');
+  if (!i18n.isInitialized) {
+    await i18n.use(initReactI18next).init({
+      lng: 'en',
+      fallbackLng: 'en',
+      resources: { en: { translation: {} } },
+      interpolation: { escapeValue: false },
+      returnEmptyString: false,
+    });
+  }
+  return { useTranslation };
+});
+
+vi.mock('react-router-dom', () => ({
+  useHistory: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('../../../utils/azure/az-cli', () => ({
+  checkNamespaceExists: vi.fn(),
+  createManagedNamespace: vi.fn(),
+  createNamespaceRoleAssignment: vi.fn(),
+  verifyNamespaceAccess: vi.fn(),
+}));
+
+vi.mock('../../../utils/azure/checkAzureCli', () => ({
+  checkAzureCliAndAksPreview: vi.fn().mockResolvedValue({ suggestions: [] }),
+}));
+
+vi.mock('./useAzureResources', () => ({
+  useAzureResources: () => ({
+    subscriptions: [],
+    clusters: [],
+    loading: false,
+    error: null,
+    clusterError: null,
+    loadingClusters: false,
+    totalClusterCount: 0,
+    fetchSubscriptions: vi.fn().mockResolvedValue([]),
+    fetchClusters: vi.fn().mockResolvedValue([]),
+    clearClusters: vi.fn(),
+    clearError: vi.fn(),
+    clearClusterError: vi.fn(),
+  }),
+}));
+
+vi.mock('./useClusterCapabilities', () => ({
+  useClusterCapabilities: () => ({
+    capabilities: null,
+    loading: false,
+    error: null,
+    fetchCapabilities: vi.fn(),
+    clearCapabilities: vi.fn(),
+  }),
+}));
+
+vi.mock('./useExtensionCheck', () => ({
+  useExtensionCheck: () => ({
+    installed: true,
+    installing: false,
+    error: null,
+    showSuccess: false,
+    installExtension: vi.fn(),
+    checkExtension: vi.fn(),
+    clearError: vi.fn(),
+  }),
+}));
+
+vi.mock('./useFeatureCheck', () => ({
+  useFeatureCheck: () => ({
+    registered: true,
+    state: null,
+    registering: false,
+    error: null,
+    showSuccess: false,
+    registerFeature: vi.fn(),
+    checkFeature: vi.fn(),
+    clearError: vi.fn(),
+  }),
+}));
+
+vi.mock('./useNamespaceCheck', () => ({
+  useNamespaceCheck: () => ({
+    exists: false,
+    checking: false,
+    error: null,
+    checkNamespace: vi.fn(),
+    clearStatus: vi.fn(),
+  }),
+}));
+
+vi.mock('./useFormData', () => ({
+  useFormData: () => ({
+    formData: {
+      subscription: '',
+      cluster: '',
+      resourceGroup: '',
+      projectName: 'test-project',
+      description: '',
+      cpuRequest: 2000,
+      cpuLimit: 2000,
+      memoryRequest: 4096,
+      memoryLimit: 4096,
+      ingress: 'AllowSameNamespace',
+      egress: 'AllowAll',
+      userAssignments: [],
+    },
+    updateFormData: vi.fn(),
+    resetFormData: vi.fn(),
+    setFormDataField: vi.fn(),
+  }),
+}));
+
+vi.mock('./useValidation', () => ({
+  useValidation: () => ({ isValid: true, errors: {}, warnings: [], fieldErrors: {} }),
+}));
+
+vi.mock('@kinvolk/headlamp-plugin/lib/lib/k8s', () => ({
+  useClustersConf: () => ({}),
+}));
+
+import { checkNamespaceExists, createManagedNamespace } from '../../../utils/azure/az-cli';
+import { useCreateAKSProjectWizard } from './useCreateAKSProjectWizard';
+
+describe('useCreateAKSProjectWizard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('has initial activeStep of 0', () => {
+    const { result } = renderHook(() => useCreateAKSProjectWizard());
+    expect(result.current.activeStep).toBe(0);
+  });
+
+  it('handleNext increments activeStep', () => {
+    const { result } = renderHook(() => useCreateAKSProjectWizard());
+    act(() => {
+      result.current.handleNext();
+    });
+    expect(result.current.activeStep).toBe(1);
+  });
+
+  it('handleBack decrements activeStep', () => {
+    const { result } = renderHook(() => useCreateAKSProjectWizard());
+    act(() => {
+      result.current.handleNext();
+    });
+    act(() => {
+      result.current.handleBack();
+    });
+    expect(result.current.activeStep).toBe(0);
+  });
+
+  it('onBack calls history.push("/")', () => {
+    // We check indirectly — onBack should not throw
+    const { result } = renderHook(() => useCreateAKSProjectWizard());
+    expect(() => {
+      act(() => {
+        result.current.onBack();
+      });
+    }).not.toThrow();
+  });
+
+  it('initial isCreating is false', () => {
+    const { result } = renderHook(() => useCreateAKSProjectWizard());
+    expect(result.current.isCreating).toBe(false);
+  });
+
+  it('handleSubmit success path: sets showSuccessDialog after success and timer', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: false });
+
+    // Return success immediately, skip all internal delays by resolving everything fast
+    vi.mocked(createManagedNamespace).mockResolvedValue({ success: true } as any);
+    vi.mocked(checkNamespaceExists).mockResolvedValue({ exists: true } as any);
+
+    const { result } = renderHook(() => useCreateAKSProjectWizard());
+
+    // Start the submit and run all scheduled timers+microtasks deterministically
+    await act(async () => {
+      const submitPromise = result.current.handleSubmit();
+      await vi.runAllTimersAsync();
+      await submitPromise;
+    });
+
+    expect(result.current.isCreating).toBe(false);
+  }, 10000);
+
+  it('handleSubmit error path: sets creationError when createManagedNamespace fails', async () => {
+    vi.mocked(createManagedNamespace).mockResolvedValue({
+      success: false,
+      error: 'boom',
+    } as any);
+
+    const { result } = renderHook(() => useCreateAKSProjectWizard());
+
+    await act(async () => {
+      await result.current.handleSubmit();
+    });
+
+    expect(result.current.creationError).toBeTruthy();
+    expect(result.current.isCreating).toBe(false);
+  });
+
+  it('handleSubmit sets isCreating false after error completion', async () => {
+    vi.mocked(createManagedNamespace).mockResolvedValue({
+      success: false,
+      error: 'quick-fail',
+    } as any);
+
+    const { result } = renderHook(() => useCreateAKSProjectWizard());
+
+    await act(async () => {
+      await result.current.handleSubmit();
+    });
+
+    expect(result.current.isCreating).toBe(false);
+  });
+});

--- a/plugins/aks-desktop/src/components/CreateAKSProject/hooks/useCreateAKSProjectWizard.ts
+++ b/plugins/aks-desktop/src/components/CreateAKSProject/hooks/useCreateAKSProjectWizard.ts
@@ -1,0 +1,597 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
+import { useClustersConf } from '@kinvolk/headlamp-plugin/lib/lib/k8s';
+import React, { useEffect, useRef, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import {
+  checkNamespaceExists,
+  createManagedNamespace,
+  createNamespaceRoleAssignment,
+  verifyNamespaceAccess,
+} from '../../../utils/azure/az-cli';
+import { checkAzureCliAndAksPreview } from '../../../utils/azure/checkAzureCli';
+import { mapUIRoleToAzureRole, STEPS } from '../types';
+import { useAzureResources } from './useAzureResources';
+import { useClusterCapabilities } from './useClusterCapabilities';
+import { useExtensionCheck } from './useExtensionCheck';
+import { useFeatureCheck } from './useFeatureCheck';
+import { useFormData } from './useFormData';
+import { useNamespaceCheck } from './useNamespaceCheck';
+import { useValidation } from './useValidation';
+
+/** Set to `true` locally to enable verbose debug logging. Never enable in production. */
+const DEBUG = false;
+
+/**
+ * All state and handlers returned by {@link useCreateAKSProjectWizard}.
+ * Pass the whole object (plus a few derived values) into
+ * {@link CreateAKSProjectPure} as props.
+ */
+export interface UseCreateAKSProjectWizardResult {
+  // ── Step navigation ──────────────────────────────────────────────────────
+  /** Zero-based index of the currently visible wizard step. */
+  activeStep: number;
+  /** Ordered step labels used to render the breadcrumb navigation bar. */
+  steps: typeof STEPS;
+  /** Advances `activeStep` and clears any Azure resource errors. */
+  handleNext: () => void;
+  /** Decrements `activeStep`. */
+  handleBack: () => void;
+  /** Jumps directly to `step`. */
+  handleStepClick: (step: number) => void;
+  /**
+   * Submits the project-creation form.  Creates the managed namespace,
+   * polls for readiness, assigns user roles, and updates the creation
+   * overlay state throughout.  A 10-minute timeout guard prevents silent hangs.
+   */
+  handleSubmit: () => Promise<void>;
+  /** Navigates back to the home route (`/`). */
+  onBack: () => void;
+
+  // ── Creation-overlay state ────────────────────────────────────────────────
+  /** `true` while the namespace-creation request is in-flight. */
+  isCreating: boolean;
+  /** Status message updated at each stage of the creation process. */
+  creationProgress: string;
+  /** Error message if creation failed, or `null` when not in an error state. */
+  creationError: string | null;
+  /** Direct setter for {@link creationError} (used by the connector to dismiss the overlay). */
+  setCreationError: React.Dispatch<React.SetStateAction<string | null>>;
+  /** Direct setter for {@link creationProgress} (used by the connector to clear on dismiss). */
+  setCreationProgress: React.Dispatch<React.SetStateAction<string>>;
+  /** `true` when the project was created successfully and the success dialog is open. */
+  showSuccessDialog: boolean;
+  /** Direct setter for {@link showSuccessDialog}. */
+  setShowSuccessDialog: React.Dispatch<React.SetStateAction<boolean>>;
+  /** Name of the first application entered by the user in the success dialog. */
+  applicationName: string;
+  /** Setter for {@link applicationName}. */
+  setApplicationName: React.Dispatch<React.SetStateAction<string>>;
+
+  // ── CLI suggestions ───────────────────────────────────────────────────────
+  /**
+   * Warning messages returned by `checkAzureCliAndAksPreview` on mount.
+   * Non-empty when the Azure CLI or required extensions are missing.
+   */
+  cliSuggestions: string[];
+
+  // ── Sub-hook results (forwarded to step components) ───────────────────────
+  /** Collected form values from the wizard steps. */
+  formData: ReturnType<typeof useFormData>['formData'];
+  /** Updates a single key in {@link formData}. */
+  updateFormData: ReturnType<typeof useFormData>['updateFormData'];
+  /** Subscriptions, clusters, loading states, and fetch actions for Azure resources. */
+  azureResources: ReturnType<typeof useAzureResources>;
+  /** Extension install status and action for the aks-preview CLI extension. */
+  extensionStatus: ReturnType<typeof useExtensionCheck>;
+  /** Feature registration status and action for the required AKS feature flag. */
+  featureStatus: ReturnType<typeof useFeatureCheck>;
+  /** Namespace existence check state and action. */
+  namespaceCheck: ReturnType<typeof useNamespaceCheck>;
+  /** Cluster capability flags (SKU, network policy, add-on status). */
+  clusterCapabilities: ReturnType<typeof useClusterCapabilities>;
+  /** Per-step validation result used to gate the "Next" / "Create Project" button. */
+  validation: ReturnType<typeof useValidation>;
+  /**
+   * `true` when the cluster name in the form is not found in the local Headlamp
+   * cluster registry, `undefined` when no cluster is selected.
+   */
+  isClusterMissing: boolean | undefined;
+}
+
+/**
+ * Manages all wizard state and side-effects for the Create AKS Project flow.
+ *
+ * Extracted from `CreateAKSProject.tsx` so it can be unit-tested independently
+ * and so that {@link CreateAKSProjectPure} remains a pure presentational component.
+ * The hook composes every domain-specific sub-hook and exposes a single flat
+ * object that can be spread directly onto {@link CreateAKSProjectPure}.
+ *
+ * @returns Wizard state and handlers ready to spread into {@link CreateAKSProjectPure}.
+ */
+export function useCreateAKSProjectWizard(): UseCreateAKSProjectWizardResult {
+  const history = useHistory();
+  const { t } = useTranslation();
+
+  const [activeStep, setActiveStep] = useState(0);
+  const [isCreating, setIsCreating] = useState(false);
+  const [creationProgress, setCreationProgress] = useState('');
+  const [creationError, setCreationError] = useState<string | null>(null);
+  const [showSuccessDialog, setShowSuccessDialog] = useState(false);
+  const [applicationName, setApplicationName] = useState('');
+  const [cliSuggestions, setCliSuggestions] = useState<string[]>([]);
+
+  // Track the 2-second success-dialog delay timer so it can be cleared on unmount,
+  // preventing a setState call on an unmounted component (React warning / memory leak).
+  const successTimeoutRef = useRef<number | undefined>(undefined);
+
+  const { formData, updateFormData } = useFormData();
+  const azureResources = useAzureResources();
+  const clusterCapabilities = useClusterCapabilities();
+  const extensionStatus = useExtensionCheck();
+  const featureStatus = useFeatureCheck({ subscription: formData.subscription });
+  const namespaceCheck = useNamespaceCheck();
+
+  const clustersConf = useClustersConf();
+  const isClusterMissing =
+    formData.cluster &&
+    Object.values(clustersConf).find((it: any) => it.name === formData.cluster) === undefined
+      ? true
+      : undefined;
+
+  const validation = useValidation(
+    activeStep,
+    formData,
+    extensionStatus,
+    featureStatus,
+    namespaceCheck,
+    isClusterMissing,
+    clusterCapabilities.capabilities
+  );
+
+  useEffect(() => {
+    azureResources.fetchSubscriptions();
+  }, []);
+
+  useEffect(() => {
+    (async () => {
+      const azureCheck = await checkAzureCliAndAksPreview();
+      if (DEBUG) console.log('Azure CLI check results:', azureCheck);
+      setCliSuggestions(azureCheck.suggestions);
+    })();
+  }, []);
+
+  useEffect(() => {
+    if (formData.subscription) {
+      azureResources.fetchClusters(formData.subscription);
+    } else {
+      azureResources.clearClusters();
+    }
+    clusterCapabilities.clearCapabilities();
+  }, [formData.subscription]);
+
+  useEffect(() => {
+    if (formData.cluster && formData.subscription && formData.resourceGroup) {
+      clusterCapabilities.fetchCapabilities(
+        formData.subscription,
+        formData.resourceGroup,
+        formData.cluster
+      );
+    } else {
+      clusterCapabilities.clearCapabilities();
+    }
+  }, [formData.cluster, formData.subscription, formData.resourceGroup]);
+
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      if (
+        formData.projectName &&
+        formData.cluster &&
+        formData.resourceGroup &&
+        formData.subscription
+      ) {
+        namespaceCheck.checkNamespace(
+          formData.cluster,
+          formData.resourceGroup,
+          formData.projectName,
+          formData.subscription
+        );
+      }
+    }, 500);
+
+    return () => clearTimeout(timeoutId);
+  }, [formData.projectName, formData.cluster, formData.resourceGroup, formData.subscription]);
+
+  // Clear the success-dialog delay timer when the hook unmounts so we never call
+  // setState after the component has been removed from the tree.
+  useEffect(() => {
+    return () => {
+      clearTimeout(successTimeoutRef.current);
+    };
+  }, []);
+
+  const handleNext = () => {
+    azureResources.clearError();
+    azureResources.clearClusterError();
+    setActiveStep(prevStep => prevStep + 1);
+  };
+
+  const handleBack = () => {
+    setActiveStep(prevStep => prevStep - 1);
+  };
+
+  const handleStepClick = (step: number) => {
+    // Block breadcrumb navigation while a creation request is in-flight to prevent
+    // navigating away mid-creation which could corrupt the wizard state.
+    if (isCreating) return;
+    setActiveStep(step);
+  };
+
+  const handleSubmit = async () => {
+    let creationTimeoutId: number | undefined;
+    try {
+      if (DEBUG)
+        console.log('handleSubmit', {
+          cluster: formData.cluster,
+          projectName: formData.projectName,
+        });
+
+      setIsCreating(true);
+      setCreationError(null);
+      setCreationProgress(`${t('Starting project creation')}...`);
+
+      const timeoutPromise = new Promise((_, reject) => {
+        creationTimeoutId = window.setTimeout(() => {
+          reject(
+            new Error(
+              t(
+                'Project creation timed out after 10 minutes. Please check if the namespace was created and try again.'
+              )
+            )
+          );
+        }, 10 * 60 * 1000);
+      });
+
+      const creationPromise = (async () => {
+        setCreationProgress(`${t('Initiating managed namespace creation')}...`);
+        const namespaceResult = await createManagedNamespace({
+          clusterName: formData.cluster,
+          resourceGroup: formData.resourceGroup,
+          namespaceName: formData.projectName,
+          subscriptionId: formData.subscription,
+          cpuRequest: formData.cpuRequest,
+          cpuLimit: formData.cpuLimit,
+          memoryRequest: formData.memoryRequest,
+          memoryLimit: formData.memoryLimit,
+          ingressPolicy: formData.ingress,
+          egressPolicy: formData.egress,
+          labels: {
+            'headlamp.dev/project-id': formData.projectName,
+            'headlamp.dev/project-managed-by': 'aks-desktop',
+            'aks-desktop/project-subscription': formData.subscription,
+            'aks-desktop/project-resource-group': formData.resourceGroup,
+          },
+        });
+
+        if (!namespaceResult.success) {
+          throw new Error(
+            t('Namespace creation failed: {{message}}', {
+              message: namespaceResult.error || t('Unknown error'),
+            })
+          );
+        }
+
+        setCreationProgress(`${t('Namespace creation initiated! Monitoring creation status')}...`);
+        if (DEBUG)
+          console.log('🚀 Namespace creation initiated for namespace:', formData.projectName);
+
+        if (DEBUG) console.log('⏳ Waiting 5 seconds for namespace to propagate...');
+        setCreationProgress(`${t('Waiting for namespace to propagate')}...`);
+        await new Promise(resolve => setTimeout(resolve, 5000));
+
+        let namespaceVerified = false;
+        let retryCount = 0;
+        const maxRetries = 8;
+        const retryDelay = 4000;
+
+        while (!namespaceVerified && retryCount < maxRetries) {
+          try {
+            if (DEBUG)
+              console.log(
+                `🔍 Verification attempt ${retryCount + 1} for namespace: ${formData.projectName}`
+              );
+
+            const result = await checkNamespaceExists(
+              formData.cluster,
+              formData.resourceGroup,
+              formData.projectName,
+              formData.subscription
+            );
+
+            if (DEBUG) {
+              console.log(`   Direct result exists: ${result.exists}`);
+              console.log(`   Direct result error: ${result.error || 'None'}`);
+            }
+
+            if (result.error) {
+              if (DEBUG) console.log(`   ❌ Namespace check error: ${result.error}`);
+              throw new Error(
+                t('Namespace status check failed: {{message}}', { message: result.error })
+              );
+            }
+
+            if (result.exists === true) {
+              namespaceVerified = true;
+              if (DEBUG) console.log('✅ Namespace verified successfully');
+            } else {
+              retryCount++;
+              if (retryCount < maxRetries) {
+                if (DEBUG)
+                  console.log(`⏳ Namespace not found yet, retrying in ${retryDelay / 1000}s...`);
+                setCreationProgress(`${t('Waiting for namespace to be created')}...`);
+                await new Promise(resolve => setTimeout(resolve, retryDelay));
+              } else {
+                if (DEBUG) console.log(`❌ Max retries reached, namespace still not found`);
+              }
+            }
+          } catch (statusError) {
+            const statusErrorMessage =
+              statusError instanceof Error ? statusError.message : String(statusError);
+            if (DEBUG) console.log(`❌ Verification attempt failed:`, statusErrorMessage);
+            throw new Error(
+              t('Namespace status verification failed: {{message}}', {
+                message: statusErrorMessage,
+              })
+            );
+          }
+        }
+
+        if (!namespaceVerified) {
+          if (DEBUG)
+            console.log('⚠️ Namespace verification failed, continuing (timing issue likely).');
+          setCreationProgress(
+            `${t('Namespace creation API succeeded, proceeding with user assignments')}...`
+          );
+        }
+
+        setCreationProgress(
+          `${t('Namespace creation completed successfully! Adding user access')}...`
+        );
+
+        const validAssignments = formData.userAssignments.filter(
+          assignment => assignment.email.trim() !== ''
+        );
+
+        if (validAssignments.length > 0) {
+          setCreationProgress(
+            `${t('Adding user access for {{count}} assignee', {
+              count: validAssignments.length,
+            })}...`
+          );
+
+          const assignmentResults = [];
+          const assignmentErrors = [];
+
+          for (let index = 0; index < validAssignments.length; index++) {
+            const assignment = validAssignments[index];
+            setCreationProgress(`${t('Adding user {{email}}', { email: assignment.email })}...`);
+
+            try {
+              const azureRole = mapUIRoleToAzureRole(assignment.role);
+
+              const rolesToAssign = [
+                azureRole,
+                'Azure Kubernetes Service Namespace User',
+                'Azure Kubernetes Service Namespace Contributor',
+              ];
+
+              const roleAssignmentResults = [];
+              for (const role of rolesToAssign) {
+                setCreationProgress(
+                  `${t('Assigning {{role}} to {{email}}', {
+                    role,
+                    email: assignment.email,
+                  })}...`
+                );
+
+                const roleResult = await createNamespaceRoleAssignment({
+                  clusterName: formData.cluster,
+                  resourceGroup: formData.resourceGroup,
+                  namespaceName: formData.projectName,
+                  assignee: assignment.email,
+                  role: role,
+                  subscriptionId: formData.subscription,
+                });
+
+                if (!roleResult.success) {
+                  const errorDetails = roleResult.stderr || roleResult.error || t('Unknown error');
+                  roleAssignmentResults.push({
+                    role,
+                    success: false,
+                    error: errorDetails,
+                    errorField: roleResult.error,
+                    stderr: roleResult.stderr,
+                  });
+                } else {
+                  roleAssignmentResults.push({ role, success: true });
+                }
+              }
+
+              const failedRoles = roleAssignmentResults.filter(r => !r.success && !r.skipped);
+              if (failedRoles.length > 0) {
+                const failedRoleDetails = failedRoles
+                  .map(r => {
+                    const errorMsg = r.stderr || r.error || t('Unknown error');
+                    return `${r.role}: ${errorMsg}`;
+                  })
+                  .join('; ');
+                assignmentErrors.push(
+                  t('Failed to assign roles to user {{email}}. {{details}}', {
+                    email: assignment.email,
+                    details: failedRoleDetails,
+                  })
+                );
+                continue;
+              }
+
+              setCreationProgress(
+                `${t('Verifying access for user {{email}}', { email: assignment.email })}...`
+              );
+              const verifyResult = await verifyNamespaceAccess({
+                clusterName: formData.cluster,
+                resourceGroup: formData.resourceGroup,
+                namespaceName: formData.projectName,
+                assignee: assignment.email,
+                subscriptionId: formData.subscription,
+              });
+
+              if (!verifyResult.success) {
+                assignmentErrors.push(
+                  t('Failed to verify access for user {{email}}: {{message}}', {
+                    email: assignment.email,
+                    message: verifyResult.error || t('Verification failed'),
+                  })
+                );
+              } else if (!verifyResult.hasAccess) {
+                assignmentErrors.push(
+                  t('User {{email}} does not have the expected access to the namespace', {
+                    email: assignment.email,
+                  })
+                );
+              } else {
+                assignmentResults.push(
+                  '✓ ' + t('User {{email}} added successfully', { email: assignment.email })
+                );
+              }
+            } catch (userError) {
+              assignmentErrors.push(
+                t('Error processing user {{email}}: {{message}}', {
+                  email: assignment.email,
+                  message: userError instanceof Error ? userError.message : String(userError),
+                })
+              );
+            }
+          }
+
+          if (assignmentErrors.length > 0) {
+            const errorMessage = `${t(
+              'User assignment completed with errors'
+            )}\n${assignmentErrors.join('\n')}`;
+            if (assignmentResults.length > 0) {
+              if (DEBUG) console.log('Some user assignments succeeded:', assignmentResults.length);
+            }
+            throw new Error(errorMessage);
+          }
+        } else {
+          setCreationProgress(`${t('No user assignments to process')}...`);
+        }
+
+        setCreationProgress(t('Project creation completed successfully!'));
+
+        setCreationProgress(`${t('Performing final status verification')}...`);
+
+        let finalVerified = false;
+        for (let attempt = 0; attempt < 2 && !finalVerified; attempt++) {
+          try {
+            const result = await checkNamespaceExists(
+              formData.cluster,
+              formData.resourceGroup,
+              formData.projectName,
+              formData.subscription
+            );
+
+            if (result.error) {
+              throw new Error(
+                t('Final status check failed: {{message}}', { message: result.error })
+              );
+            }
+
+            if (result.exists) {
+              finalVerified = true;
+              if (DEBUG) console.log('✅ Final namespace verification successful');
+            } else if (attempt === 0) {
+              if (DEBUG)
+                console.log('⏳ Final verification: namespace not found, retrying once...');
+              await new Promise(resolve => setTimeout(resolve, 2000));
+            }
+          } catch (finalError) {
+            const finalErrorMessage =
+              finalError instanceof Error ? finalError.message : String(finalError);
+            throw new Error(
+              t('Final status verification failed: {{message}}', {
+                message: finalErrorMessage,
+              })
+            );
+          }
+        }
+
+        if (!finalVerified) {
+          if (DEBUG)
+            console.log('⚠️ Final verification failed, but namespace creation API succeeded.');
+        }
+
+        setCreationProgress(t('All verifications completed successfully!'));
+      })();
+
+      await Promise.race([creationPromise, timeoutPromise]);
+
+      // Store the timer id so the cleanup effect can cancel it if the component
+      // unmounts before the 2 seconds elapse, preventing setState on an unmounted component.
+      successTimeoutRef.current = window.setTimeout(() => {
+        setIsCreating(false);
+        setShowSuccessDialog(true);
+      }, 2000);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorStack = error instanceof Error ? error.stack : undefined;
+      console.error('Error creating AKS project:', error);
+      console.error('Error details:', {
+        message: errorMessage,
+        stack: errorStack,
+        formDataRedacted: true,
+      });
+      setCreationError(errorMessage || t('Failed to create project'));
+      setIsCreating(false);
+      setCreationProgress('');
+    } finally {
+      // Clear the 10-minute guard timer so it cannot fire (and cause an unhandled
+      // rejection) after creationPromise has already won the Promise.race.
+      clearTimeout(creationTimeoutId);
+    }
+  };
+
+  const onBack = () => {
+    history.push('/');
+  };
+
+  return {
+    activeStep,
+    steps: STEPS,
+    handleNext,
+    handleBack,
+    handleStepClick,
+    handleSubmit,
+    onBack,
+    isCreating,
+    creationProgress,
+    creationError,
+    setCreationError,
+    setCreationProgress,
+    showSuccessDialog,
+    setShowSuccessDialog,
+    applicationName,
+    setApplicationName,
+    cliSuggestions,
+    formData,
+    updateFormData,
+    azureResources,
+    extensionStatus,
+    featureStatus,
+    namespaceCheck,
+    clusterCapabilities,
+    validation,
+    isClusterMissing,
+  };
+}

--- a/plugins/aks-desktop/src/components/CreateAKSProject/hooks/useNamespaceCheck.ts
+++ b/plugins/aks-desktop/src/components/CreateAKSProject/hooks/useNamespaceCheck.ts
@@ -5,6 +5,9 @@ import { useCallback, useState } from 'react';
 import { checkNamespaceExists } from '../../../utils/azure/az-cli';
 import type { NamespaceStatus } from '../types';
 
+/** Set to `true` locally to enable verbose debug logging. Never enable in production. */
+const DEBUG = false;
+
 /**
  * Custom hook for managing namespace existence checks
  */
@@ -35,12 +38,10 @@ export const useNamespaceCheck = () => {
       try {
         setStatus(prev => ({ ...prev, checking: true, error: null }));
 
-        console.log('🔍 Checking namespace existence:', {
-          cluster: clusterName,
-          resourceGroup,
-          namespace: namespaceName,
-          subscription: subscriptionId,
-        });
+        if (DEBUG)
+          console.log('🔍 Checking namespace existence:', {
+            namespace: namespaceName,
+          });
 
         const result = await checkNamespaceExists(
           clusterName,
@@ -49,7 +50,7 @@ export const useNamespaceCheck = () => {
           subscriptionId
         );
 
-        console.log('📋 Namespace check result:', result);
+        if (DEBUG) console.log('📋 Namespace check result:', result.exists);
 
         if (result.error) {
           setStatus(prev => ({

--- a/plugins/aks-desktop/src/components/DeployWizard/DeployWizard.tsx
+++ b/plugins/aks-desktop/src/components/DeployWizard/DeployWizard.tsx
@@ -1,187 +1,59 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
-import { apply } from '@kinvolk/headlamp-plugin/lib/ApiProxy';
-import {
-  Box,
-  Button,
-  Card,
-  CardContent,
-  CircularProgress,
-  Container,
-  Typography,
-} from '@mui/material';
-import React, { useEffect, useState } from 'react';
-import YAML from 'yaml';
-import { Breadcrumb } from '../CreateAKSProject/components/Breadcrumb';
+import React from 'react';
 import ConfigureContainer from './components/ConfigureContainer';
 import ConfigureYAML from './components/ConfigureYAML';
 import Deploy from './components/Deploy';
 import SourceStep from './components/SourceStep';
-import { useContainerConfiguration } from './hooks/useContainerConfiguration';
-import { applyNamespaceOverride } from './utils/namespaceOverride';
-import { generateYamlForContainer } from './utils/yamlGenerator';
+import DeployWizardPure from './DeployWizardPure';
+import { useDeployWizard, WizardStep } from './hooks/useDeployWizard';
 
+/** Options accepted by the {@link DeployWizard} connector. */
 type DeployWizardProps = {
+  /** Target cluster passed to `apply` when deploying resources. */
   cluster?: string;
+  /** Target namespace injected into generated/parsed YAML before deployment. */
   namespace?: string;
+  /** Pre-fills the application-name field in the container-configuration step. */
   initialApplicationName?: string;
+  /** Called when the user clicks "Close" after a deploy result. */
   onClose?: () => void;
 };
 
-enum WizardStep {
-  SOURCE = 0,
-  CONFIGURE = 1,
-  DEPLOY = 2,
-}
+/**
+ * Thin connector that wires {@link useDeployWizard} into {@link DeployWizardPure}.
+ *
+ * Composes the wizard state hook and the step-specific child components, then
+ * passes the full state bag to the pure presentational view. All business logic
+ * lives in the hook; all rendering lives in the view.
+ */
 
-export default function DeployWizard({
-  cluster,
-  namespace,
-  initialApplicationName,
-  onClose,
-}: DeployWizardProps) {
-  const { t } = useTranslation();
-  const [activeStep, setActiveStep] = useState(WizardStep.SOURCE);
-  const [sourceType, setSourceType] = useState<null | 'yaml' | 'container'>(null);
-  const [yamlEditorValue, setYamlEditorValue] = useState<string>('');
-  const [yamlError, setYamlError] = useState<string | null>(null);
-  const [deploying, setDeploying] = useState(false);
-  const [deployResult, setDeployResult] = useState<null | 'success' | 'error'>(null);
-  const [deployMessage, setDeployMessage] = useState<string>('');
-  const [userPreviewYaml, setUserPreviewYaml] = useState<string>('');
-
-  // Container configuration state
-  const containerConfig = useContainerConfiguration(initialApplicationName);
-
-  useEffect(() => {
-    if (activeStep === WizardStep.DEPLOY && sourceType === 'container') {
-      containerConfig.setConfig(prev => ({
-        ...prev,
-        containerPreviewYaml: generateYamlForContainer({
-          ...prev,
-          namespace,
-        }),
-      }));
-    }
-    // Generate preview with namespace override for user YAML in the Review step
-    if (activeStep === WizardStep.DEPLOY && sourceType === 'yaml') {
-      try {
-        const text = yamlEditorValue;
-        const docs = YAML.parseAllDocuments(text).filter(d => d && d.contents);
-        const processed = docs
-          .map(d => d.toJSON())
-          .filter(Boolean)
-          .map(obj => applyNamespaceOverride(obj, namespace))
-          .map(obj => YAML.stringify(obj).trim());
-        setUserPreviewYaml(processed.join('\n---\n'));
-      } catch (e) {
-        // If parsing fails, fall back to raw
-        setUserPreviewYaml(yamlEditorValue);
-      }
-    }
-    // When leaving the Review step, clear any previous deploy result/message
-    if (activeStep !== WizardStep.DEPLOY) {
-      setDeployResult(null);
-      setDeployMessage('');
-      setDeploying(false);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeStep, sourceType, namespace, yamlEditorValue, containerConfig.config]);
-
-  const isStepValid = (step: WizardStep): boolean => {
-    switch (step) {
-      case WizardStep.SOURCE:
-        return sourceType !== null;
-      case WizardStep.CONFIGURE:
-        if (sourceType === 'yaml') {
-          return yamlEditorValue.trim().length > 0;
-        }
-        if (sourceType === 'container') {
-          return (
-            containerConfig.config.appName.trim().length > 0 &&
-            containerConfig.config.containerImage.trim().length > 0
-          );
-        }
-        return false;
-      case WizardStep.DEPLOY:
-        return isStepValid(WizardStep.SOURCE) && isStepValid(WizardStep.CONFIGURE);
-      default:
-        return true;
-    }
-  };
-
-  const handleNext = () => setActiveStep(s => Math.min(s + 1, WizardStep.DEPLOY));
-  const handleBack = () => setActiveStep(s => Math.max(s - 1, WizardStep.SOURCE));
-  const handleStepClick = (step: number) => {
-    // Only allow clicking on the current step or previous steps that are valid
-    if (step <= activeStep || isStepValid(step as WizardStep)) {
-      setActiveStep(step);
-    }
-  };
-
-  const handleDeploy = async () => {
-    try {
-      setYamlError(null);
-      setDeployResult(null);
-      setDeployMessage('');
-      setDeploying(true);
-
-      const text =
-        sourceType === 'container' ? containerConfig.config.containerPreviewYaml : yamlEditorValue;
-
-      // Validate YAML before deploying
-      let parsedDocs;
-      try {
-        parsedDocs = YAML.parseAllDocuments(text);
-        // Validate each document
-        for (const doc of parsedDocs) {
-          const json = doc.toJSON();
-          if (!json || !json.kind || !json.metadata?.name) {
-            throw new Error(t('Invalid YAML: missing required fields (kind or metadata.name)'));
-          }
-        }
-      } catch (e: any) {
-        setYamlError(e?.message || t('Invalid YAML'));
-        setDeployResult('error');
-        setDeployMessage(e?.message || t('Invalid YAML'));
-        setDeploying(false);
-        return;
-      }
-
-      const docs = parsedDocs
-        .map(d => d.toJSON())
-        .filter(Boolean)
-        .map(obj => (sourceType === 'yaml' ? applyNamespaceOverride(obj, namespace) : obj));
-
-      let applied = 0;
-      for (const resource of docs) {
-        if (!resource || typeof resource !== 'object') continue;
-        await apply(resource as any, cluster);
-        applied++;
-      }
-      setDeployResult('success');
-      setDeployMessage(
-        t('Applied {{count}} resource successfully.', {
-          count: applied,
-        })
-      );
-    } catch (e: any) {
-      setDeployResult('error');
-      setDeployMessage(e?.message || t('Failed to apply resources.'));
-    } finally {
-      setDeploying(false);
-    }
-  };
+export default function DeployWizard(props: DeployWizardProps) {
+  const wizardState = useDeployWizard(props);
 
   const renderStepContent = () => {
+    const {
+      activeStep,
+      sourceType,
+      yamlEditorValue,
+      yamlError,
+      setYamlEditorValue,
+      setYamlError,
+      containerConfig,
+      userPreviewYaml,
+      deployResult,
+      deployMessage,
+    } = wizardState;
+
     switch (activeStep) {
       case WizardStep.SOURCE:
-        return <SourceStep sourceType={sourceType} onSourceTypeChange={setSourceType} />;
+        return (
+          <SourceStep sourceType={sourceType} onSourceTypeChange={wizardState.setSourceType} />
+        );
       case WizardStep.CONFIGURE:
         return (
-          <Box>
+          <React.Fragment>
             {sourceType === 'yaml' ? (
               <ConfigureYAML
                 yamlEditorValue={yamlEditorValue}
@@ -192,13 +64,13 @@ export default function DeployWizard({
             ) : (
               <ConfigureContainer containerConfig={containerConfig} />
             )}
-          </Box>
+          </React.Fragment>
         );
       case WizardStep.DEPLOY:
         return (
           <Deploy
             sourceType={sourceType}
-            namespace={namespace}
+            namespace={props.namespace}
             yamlEditorValue={yamlEditorValue}
             userPreviewYaml={userPreviewYaml}
             containerPreviewYaml={containerConfig.config.containerPreviewYaml}
@@ -212,86 +84,11 @@ export default function DeployWizard({
   };
 
   return (
-    // Todo: noScroll could be done like this? <Container maxWidth="lg" sx={{ py: 3, overflow: 'hidden' }}>
-    <Container maxWidth="lg" sx={{ py: 3 }}>
-      <Typography
-        id="deploy-wizard-dialog-title"
-        variant="h4"
-        gutterBottom
-        sx={{ fontWeight: 600, mb: 2 }}
-      >
-        {t('Deploy Application')}
-      </Typography>
-      <Card>
-        <CardContent sx={{ p: 0 }}>
-          <Box>
-            <Breadcrumb
-              steps={[t('Source'), t('Configure'), t('Deploy')]}
-              activeStep={activeStep}
-              onStepClick={handleStepClick}
-            />
-          </Box>
-          <Box
-            sx={{
-              height: '55vh',
-              overflowY: 'auto',
-              overflowX: 'hidden',
-              px: 3,
-              pt: 3,
-            }}
-          >
-            {renderStepContent()}
-          </Box>
-          <Box
-            sx={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-              px: 3,
-              py: 3,
-              borderTop: '1px solid',
-              borderColor: 'divider',
-              marginTop: 2,
-            }}
-          >
-            {activeStep === WizardStep.DEPLOY ? (
-              <Box sx={{ width: '100%', display: 'flex', justifyContent: 'flex-end' }}>
-                {deployResult ? (
-                  <Button variant="contained" onClick={onClose}>
-                    {t('Close')}
-                  </Button>
-                ) : (
-                  <Button
-                    variant="contained"
-                    onClick={handleDeploy}
-                    disabled={deploying}
-                    startIcon={deploying ? <CircularProgress size={20} /> : null}
-                  >
-                    {deploying ? `${t('Deploying')}...` : t('Deploy')}
-                  </Button>
-                )}
-              </Box>
-            ) : (
-              <>
-                <Box>
-                  {activeStep > WizardStep.SOURCE && (
-                    <Button variant="outlined" onClick={handleBack}>
-                      {t('Back')}
-                    </Button>
-                  )}
-                </Box>
-                <Button
-                  variant="contained"
-                  onClick={handleNext}
-                  disabled={!isStepValid(activeStep)}
-                >
-                  {t('Next')}
-                </Button>
-              </>
-            )}
-          </Box>
-        </CardContent>
-      </Card>
-    </Container>
+    <DeployWizardPure
+      {...wizardState}
+      namespace={props.namespace}
+      onClose={props.onClose}
+      stepContent={renderStepContent()}
+    />
   );
 }

--- a/plugins/aks-desktop/src/components/DeployWizard/DeployWizardPure.stories.tsx
+++ b/plugins/aks-desktop/src/components/DeployWizard/DeployWizardPure.stories.tsx
@@ -1,0 +1,169 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { Meta, StoryFn } from '@storybook/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import DeployWizardPure, { DeployWizardPureProps } from './DeployWizardPure';
+
+const noOp = () => {};
+const noOpAsync = async () => {};
+
+const containerConfigStub = {
+  config: {
+    containerStep: 0,
+    appName: '',
+    containerImage: '',
+    replicas: 1,
+    targetPort: 80,
+    servicePort: 80,
+    useCustomServicePort: false,
+    serviceType: 'ClusterIP' as const,
+    enableResources: true,
+    cpuRequest: '100m',
+    cpuLimit: '500m',
+    memoryRequest: '128Mi',
+    memoryLimit: '512Mi',
+    envVars: [{ key: '', value: '' }],
+    enableLivenessProbe: true,
+    enableReadinessProbe: true,
+    enableStartupProbe: true,
+    showProbeConfigs: false,
+    livenessPath: '/',
+    readinessPath: '/',
+    startupPath: '/',
+    livenessInitialDelay: 10,
+    livenessPeriod: 10,
+    livenessTimeout: 1,
+    livenessFailure: 3,
+    livenessSuccess: 1,
+    readinessInitialDelay: 5,
+    readinessPeriod: 10,
+    readinessTimeout: 1,
+    readinessFailure: 3,
+    readinessSuccess: 1,
+    startupInitialDelay: 0,
+    startupPeriod: 10,
+    startupTimeout: 1,
+    startupFailure: 30,
+    startupSuccess: 1,
+    enableHpa: false,
+    hpaMinReplicas: 1,
+    hpaMaxReplicas: 5,
+    hpaTargetCpu: 70,
+    runAsNonRoot: false,
+    readOnlyRootFilesystem: false,
+    allowPrivilegeEscalation: false,
+    enablePodAntiAffinity: true,
+    enableTopologySpreadConstraints: true,
+    containerPreviewYaml: '',
+  },
+  setConfig: noOp as any,
+};
+
+const baseArgs: DeployWizardPureProps = {
+  activeStep: 0,
+  sourceType: null,
+  setSourceType: noOp as any,
+  yamlEditorValue: '',
+  setYamlEditorValue: noOp as any,
+  yamlError: null,
+  setYamlError: noOp as any,
+  deploying: false,
+  deployResult: null,
+  deployMessage: '',
+  userPreviewYaml: '',
+  containerConfig: containerConfigStub,
+  namespace: 'default',
+  handleNext: noOp,
+  handleBack: noOp,
+  handleStepClick: noOp,
+  handleDeploy: noOpAsync,
+  isStepValid: () => true,
+  onClose: noOp,
+  stepContent: <div>Step content</div>,
+};
+
+export default {
+  title: 'DeployWizard/DeployWizardPure',
+  component: DeployWizardPure,
+  decorators: [
+    (Story: any) => (
+      <MemoryRouter>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
+} as Meta;
+
+const Template: StoryFn<DeployWizardPureProps> = args => <DeployWizardPure {...args} />;
+
+export const SourceStep = Template.bind({});
+SourceStep.args = {
+  ...baseArgs,
+  activeStep: 0,
+  sourceType: null,
+  stepContent: <div>Source step content</div>,
+};
+
+export const SourceStepYamlSelected = Template.bind({});
+SourceStepYamlSelected.args = {
+  ...baseArgs,
+  activeStep: 0,
+  sourceType: 'yaml',
+  stepContent: <div>Source step — YAML selected</div>,
+};
+
+export const DeployStepSuccess = Template.bind({});
+DeployStepSuccess.args = {
+  ...baseArgs,
+  activeStep: 2,
+  sourceType: 'yaml',
+  deployResult: 'success',
+  deployMessage: 'Applied 1 resource successfully.',
+  userPreviewYaml: '',
+  stepContent: <div>Deploy step content</div>,
+};
+
+export const DeployStepError = Template.bind({});
+DeployStepError.args = {
+  ...baseArgs,
+  activeStep: 2,
+  sourceType: 'yaml',
+  deployResult: 'error',
+  deployMessage:
+    'Failed to apply Deployment/web-frontend in namespace production: ImagePullBackOff — back-off pulling image "registry.example.com/web-frontend:v2.3.1": unauthorized',
+  userPreviewYaml: '',
+  stepContent: <div>Deploy step content</div>,
+};
+
+/** Deploy button in the loading / in-flight state (`deploying: true`, no result yet). */
+export const DeployStepDeploying = Template.bind({});
+DeployStepDeploying.args = {
+  ...baseArgs,
+  activeStep: 2,
+  sourceType: 'yaml',
+  deploying: true,
+  deployResult: null,
+  deployMessage: '',
+  userPreviewYaml: '',
+  stepContent: <div>Deploy step content</div>,
+};
+
+/** Container source type selected on the source step. */
+export const ContainerSourceSelected = Template.bind({});
+ContainerSourceSelected.args = {
+  ...baseArgs,
+  activeStep: 0,
+  sourceType: 'container',
+  stepContent: <div>Source step — Container selected</div>,
+};
+
+/** "Next" button disabled because the current step is invalid. */
+export const NextButtonDisabled = Template.bind({});
+NextButtonDisabled.args = {
+  ...baseArgs,
+  activeStep: 0,
+  isStepValid: () => false,
+  stepContent: <div>Source step — no source selected</div>,
+};

--- a/plugins/aks-desktop/src/components/DeployWizard/DeployWizardPure.tsx
+++ b/plugins/aks-desktop/src/components/DeployWizard/DeployWizardPure.tsx
@@ -1,0 +1,181 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CircularProgress,
+  Container,
+  Typography,
+} from '@mui/material';
+import React from 'react';
+import { Breadcrumb } from '../CreateAKSProject/components/Breadcrumb';
+import { useContainerConfiguration } from './hooks/useContainerConfiguration';
+import { WizardStep } from './hooks/useDeployWizard';
+
+/**
+ * Pure presentational props for {@link DeployWizardPure}.
+ * Every piece of state and every callback is passed in from outside;
+ * the component contains no stateful business-logic hooks (only `useTranslation` for i18n).
+ */
+export interface DeployWizardPureProps {
+  /** Index of the currently active step (see {@link WizardStep}). */
+  activeStep: number;
+  /** Selected deploy source, or `null` while the user has not yet chosen. */
+  sourceType: 'yaml' | 'container' | null;
+  /** Setter for {@link sourceType}. */
+  setSourceType: React.Dispatch<React.SetStateAction<'yaml' | 'container' | null>>;
+  /** Raw YAML text from the editor (YAML source path). */
+  yamlEditorValue: string;
+  /** Setter for {@link yamlEditorValue}. */
+  setYamlEditorValue: React.Dispatch<React.SetStateAction<string>>;
+  /** Validation error from the YAML editor, or `null` when valid. */
+  yamlError: string | null;
+  /** Setter for {@link yamlError}. */
+  setYamlError: React.Dispatch<React.SetStateAction<string | null>>;
+  /** `true` while the deploy API call is in-flight; shows a spinner on the Deploy button. */
+  deploying: boolean;
+  /** Outcome of the last deploy attempt, or `null` before the first attempt. */
+  deployResult: 'success' | 'error' | null;
+  /** Human-readable message describing the deploy outcome. */
+  deployMessage: string;
+  /** Namespace-overridden YAML for the YAML-source review step. */
+  userPreviewYaml: string;
+  /** Full container-configuration state (see `useContainerConfiguration`). */
+  containerConfig: ReturnType<typeof useContainerConfiguration>;
+  /** Target namespace; forwarded to child deploy step. */
+  namespace?: string;
+  /** Advances {@link activeStep} by one. */
+  handleNext: () => void;
+  /** Decrements {@link activeStep} by one. */
+  handleBack: () => void;
+  /** Jumps to a specific step if allowed by {@link isStepValid}. */
+  handleStepClick: (step: number) => void;
+  /** Validates and applies all Kubernetes resources from the current source. */
+  handleDeploy: () => Promise<void>;
+  /** Returns `true` when the given step has enough data to proceed. */
+  isStepValid: (step: number) => boolean;
+  /** Called when the user clicks "Close" after a deploy result. */
+  onClose?: () => void;
+  /** Step-specific content rendered inside the scrollable area (composed by the connector). */
+  stepContent: React.ReactNode;
+}
+
+/**
+ * Pure presentational component for the Deploy Application wizard.
+ *
+ * Renders the breadcrumb navigation, scrollable step area, and navigation
+ * footer. The deploy button shows an accessible loading spinner while
+ * `deploying` is `true` and disables itself to prevent duplicate submissions.
+ * Contains no stateful hooks — all business-logic state and handlers come from {@link useDeployWizard}.
+ *
+ * @see {@link useDeployWizard} for the hook that drives this component.
+ * @see {@link DeployWizardPureProps} for the full prop contract.
+ */
+
+export default function DeployWizardPure({
+  activeStep,
+  deploying,
+  deployResult,
+  handleBack,
+  handleDeploy,
+  handleNext,
+  handleStepClick,
+  isStepValid,
+  onClose,
+  stepContent,
+}: DeployWizardPureProps) {
+  const { t } = useTranslation();
+
+  return (
+    <Container maxWidth="lg" sx={{ py: 3 }}>
+      <Typography
+        id="deploy-wizard-dialog-title"
+        variant="h4"
+        gutterBottom
+        sx={{ fontWeight: 600, mb: 2 }}
+      >
+        {t('Deploy Application')}
+      </Typography>
+      <Card>
+        <CardContent sx={{ p: 0 }}>
+          <Box>
+            <Breadcrumb
+              steps={[t('Source'), t('Configure'), t('Deploy')]}
+              activeStep={activeStep}
+              onStepClick={handleStepClick}
+            />
+          </Box>
+          <Box
+            sx={{
+              height: '55vh',
+              overflowY: 'auto',
+              overflowX: 'hidden',
+              px: 3,
+              pt: 3,
+            }}
+          >
+            {stepContent}
+          </Box>
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              px: 3,
+              py: 3,
+              borderTop: '1px solid',
+              borderColor: 'divider',
+              marginTop: 2,
+            }}
+          >
+            {activeStep === WizardStep.DEPLOY ? (
+              <Box sx={{ width: '100%', display: 'flex', justifyContent: 'flex-end' }}>
+                {deployResult ? (
+                  <Button variant="contained" onClick={onClose}>
+                    {t('Close')}
+                  </Button>
+                ) : (
+                  /* aria-busy signals to AT that the Deploy button is performing an async
+                     operation. The CircularProgress spinner is hidden with aria-hidden
+                     because the button text ("Deploying...") already conveys the busy state.
+                     MDN: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-busy
+                     MDN: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-hidden */
+                  <Button
+                    variant="contained"
+                    onClick={handleDeploy}
+                    disabled={deploying}
+                    aria-busy={deploying || undefined}
+                    startIcon={deploying ? <CircularProgress size={20} aria-hidden="true" /> : null}
+                  >
+                    {deploying ? `${t('Deploying')}...` : t('Deploy')}
+                  </Button>
+                )}
+              </Box>
+            ) : (
+              <>
+                <Box>
+                  {activeStep > WizardStep.SOURCE && (
+                    <Button variant="outlined" onClick={handleBack}>
+                      {t('Back')}
+                    </Button>
+                  )}
+                </Box>
+                <Button
+                  variant="contained"
+                  onClick={handleNext}
+                  disabled={!isStepValid(activeStep)}
+                >
+                  {t('Next')}
+                </Button>
+              </>
+            )}
+          </Box>
+        </CardContent>
+      </Card>
+    </Container>
+  );
+}

--- a/plugins/aks-desktop/src/components/DeployWizard/__tests__/DeployWizardPure.a11y.test.tsx
+++ b/plugins/aks-desktop/src/components/DeployWizard/__tests__/DeployWizardPure.a11y.test.tsx
@@ -1,0 +1,202 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+// @vitest-environment jsdom
+import { cleanup, render } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+expect.extend(toHaveNoViolations);
+
+// ── module mocks ─────────────────────────────────────────────────────────────
+// Use a real i18next instance so {{variable}} interpolation works correctly in
+// rendered output. react-i18next falls back to the global i18next instance set
+// by initReactI18next, so no I18nextProvider wrapper is needed.
+vi.mock('@kinvolk/headlamp-plugin/lib', async () => {
+  const i18n = (await import('i18next')).default;
+  const { initReactI18next, useTranslation } = await import('react-i18next');
+  if (!i18n.isInitialized) {
+    await i18n.use(initReactI18next).init({
+      lng: 'en',
+      fallbackLng: 'en',
+      resources: { en: { translation: {} } },
+      interpolation: { escapeValue: false },
+      returnEmptyString: false,
+    });
+  }
+  return { useTranslation };
+});
+
+vi.mock('@iconify/react', () => ({
+  Icon: ({ icon }: any) => <span data-icon={icon} aria-hidden="true" />,
+}));
+
+// ── component under test ─────────────────────────────────────────────────────
+import DeployWizardPure, { DeployWizardPureProps } from '../DeployWizardPure';
+
+afterEach(() => cleanup());
+
+const noOp = () => {};
+const containerConfigStub = {
+  config: {
+    containerStep: 0,
+    appName: '',
+    containerImage: '',
+    replicas: 1,
+    targetPort: 80,
+    servicePort: 80,
+    useCustomServicePort: false,
+    serviceType: 'ClusterIP' as const,
+    enableResources: true,
+    cpuRequest: '100m',
+    cpuLimit: '500m',
+    memoryRequest: '128Mi',
+    memoryLimit: '512Mi',
+    envVars: [{ key: '', value: '' }],
+    enableLivenessProbe: true,
+    enableReadinessProbe: true,
+    enableStartupProbe: true,
+    showProbeConfigs: false,
+    livenessPath: '/',
+    readinessPath: '/',
+    startupPath: '/',
+    livenessInitialDelay: 10,
+    livenessPeriod: 10,
+    livenessTimeout: 1,
+    livenessFailure: 3,
+    livenessSuccess: 1,
+    readinessInitialDelay: 5,
+    readinessPeriod: 10,
+    readinessTimeout: 1,
+    readinessFailure: 3,
+    readinessSuccess: 1,
+    startupInitialDelay: 0,
+    startupPeriod: 10,
+    startupTimeout: 1,
+    startupFailure: 30,
+    startupSuccess: 1,
+    enableHpa: false,
+    hpaMinReplicas: 1,
+    hpaMaxReplicas: 5,
+    hpaTargetCpu: 70,
+    runAsNonRoot: false,
+    readOnlyRootFilesystem: false,
+    allowPrivilegeEscalation: false,
+    enablePodAntiAffinity: true,
+    enableTopologySpreadConstraints: true,
+    containerPreviewYaml: '',
+  },
+  setConfig: noOp as any,
+};
+
+const baseArgs: DeployWizardPureProps = {
+  activeStep: 0,
+  sourceType: null,
+  setSourceType: noOp as any,
+  yamlEditorValue: '',
+  setYamlEditorValue: noOp as any,
+  yamlError: null,
+  setYamlError: noOp as any,
+  deploying: false,
+  deployResult: null,
+  deployMessage: '',
+  userPreviewYaml: '',
+  containerConfig: containerConfigStub as any,
+  namespace: 'default',
+  handleNext: noOp,
+  handleBack: noOp,
+  handleStepClick: noOp,
+  handleDeploy: async () => {},
+  isStepValid: () => true,
+  onClose: noOp,
+  stepContent: <div>Step content</div>,
+};
+
+function renderInRouter(props: DeployWizardPureProps) {
+  return render(
+    <MemoryRouter>
+      <DeployWizardPure {...props} />
+    </MemoryRouter>
+  );
+}
+
+describe('DeployWizardPure a11y', () => {
+  test('SourceStep has no violations', async () => {
+    const { container } = renderInRouter({
+      ...baseArgs,
+      activeStep: 0,
+      stepContent: <div>Source step content</div>,
+    });
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  test('SourceStep YAML selected has no violations', async () => {
+    const { container } = renderInRouter({
+      ...baseArgs,
+      activeStep: 0,
+      sourceType: 'yaml',
+      stepContent: <div>Source step — YAML selected</div>,
+    });
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  test('Deploy step success has no violations', async () => {
+    const { container } = renderInRouter({
+      ...baseArgs,
+      activeStep: 2,
+      sourceType: 'yaml',
+      deployResult: 'success',
+      deployMessage: 'Applied 1 resource successfully.',
+      stepContent: <div>Deploy step content</div>,
+    });
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  test('Deploy step error has no violations', async () => {
+    const { container } = renderInRouter({
+      ...baseArgs,
+      activeStep: 2,
+      sourceType: 'yaml',
+      deployResult: 'error',
+      deployMessage: 'ImagePullBackOff',
+      stepContent: <div>Deploy step content</div>,
+    });
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  test('Deploy step deploying has no violations', async () => {
+    const { container } = renderInRouter({
+      ...baseArgs,
+      activeStep: 2,
+      sourceType: 'yaml',
+      deploying: true,
+      deployResult: null,
+      stepContent: <div>Deploy step content</div>,
+    });
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  test('Next button disabled has no violations', async () => {
+    const { container } = renderInRouter({
+      ...baseArgs,
+      activeStep: 0,
+      isStepValid: () => false,
+      stepContent: <div>Source step — no source selected</div>,
+    });
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  test('Deploy step deploying with container source has no violations', async () => {
+    const { container } = renderInRouter({
+      ...baseArgs,
+      activeStep: 2,
+      sourceType: 'container',
+      deploying: true,
+      deployResult: null,
+      stepContent: <div>Deploy step content — container</div>,
+    });
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/plugins/aks-desktop/src/components/DeployWizard/__tests__/DeployWizardPure.test.tsx
+++ b/plugins/aks-desktop/src/components/DeployWizard/__tests__/DeployWizardPure.test.tsx
@@ -1,0 +1,200 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+// @vitest-environment jsdom
+/**
+ * Interaction tests for {@link DeployWizardPure}.
+ *
+ * Each test renders the component using the args from the corresponding
+ * Storybook story so that the stories act as a single source of truth for
+ * both the visual catalogue and the interaction test matrix.
+ *
+ * Pattern:
+ *   1. Import story args.
+ *   2. Spy on every callback prop.
+ *   3. Render via RTL.
+ *   4. Simulate user gestures.
+ *   5. Assert the correct callback fired.
+ */
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// ── module mocks ─────────────────────────────────────────────────────────────
+vi.mock('@kinvolk/headlamp-plugin/lib', async () => {
+  const i18n = (await import('i18next')).default;
+  const { initReactI18next, useTranslation } = await import('react-i18next');
+  if (!i18n.isInitialized) {
+    await i18n.use(initReactI18next).init({
+      lng: 'en',
+      fallbackLng: 'en',
+      resources: { en: { translation: {} } },
+      interpolation: { escapeValue: false },
+      returnEmptyString: false,
+    });
+  }
+  return { useTranslation };
+});
+
+vi.mock('@iconify/react', () => ({
+  Icon: ({ icon }: any) => <span data-icon={icon} aria-hidden="true" />,
+}));
+
+// ── component + stories ───────────────────────────────────────────────────────
+import DeployWizardPure, { DeployWizardPureProps } from '../DeployWizardPure';
+import {
+  ContainerSourceSelected,
+  DeployStepDeploying,
+  DeployStepError,
+  DeployStepSuccess,
+  NextButtonDisabled,
+  SourceStep,
+  SourceStepYamlSelected,
+} from '../DeployWizardPure.stories';
+
+afterEach(() => cleanup());
+
+function renderStory(
+  storyArgs: DeployWizardPureProps,
+  overrides: Partial<DeployWizardPureProps> = {}
+) {
+  const props: DeployWizardPureProps = { ...storyArgs, ...overrides };
+  return render(
+    <MemoryRouter>
+      <DeployWizardPure {...props} />
+    </MemoryRouter>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('DeployWizardPure — SourceStep story interactions', () => {
+  it('renders the Deploy Application heading', () => {
+    renderStory(SourceStep.args!);
+    expect(screen.getByRole('heading', { name: /deploy application/i })).toBeInTheDocument();
+  });
+
+  it('renders the step content from the story', () => {
+    renderStory(SourceStep.args!);
+    expect(screen.getByText('Source step content')).toBeInTheDocument();
+  });
+
+  it('calls handleNext when Next button is clicked', () => {
+    const handleNext = vi.fn();
+    renderStory(SourceStep.args!, { handleNext, isStepValid: () => true });
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+    expect(handleNext).toHaveBeenCalledTimes(1);
+  });
+
+  it('Back button is absent on the first step', () => {
+    renderStory(SourceStep.args!);
+    expect(screen.queryByRole('button', { name: /^back$/i })).not.toBeInTheDocument();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('DeployWizardPure — NextButtonDisabled story interactions', () => {
+  it('Next button is disabled when isStepValid returns false', () => {
+    renderStory(NextButtonDisabled.args!);
+    expect(screen.getByRole('button', { name: /next/i })).toBeDisabled();
+  });
+
+  it('does not call handleNext when Next is clicked while disabled', () => {
+    const handleNext = vi.fn();
+    renderStory(NextButtonDisabled.args!, { handleNext });
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+    expect(handleNext).not.toHaveBeenCalled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('DeployWizardPure — SourceStepYamlSelected story interactions', () => {
+  it('renders step content for yaml selected state', () => {
+    renderStory(SourceStepYamlSelected.args!);
+    expect(screen.getByText(/yaml selected/i)).toBeInTheDocument();
+  });
+
+  it('Next button is enabled when step is valid', () => {
+    renderStory(SourceStepYamlSelected.args!, { isStepValid: () => true });
+    expect(screen.getByRole('button', { name: /next/i })).not.toBeDisabled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('DeployWizardPure — ContainerSourceSelected story interactions', () => {
+  it('renders step content for container selected state', () => {
+    renderStory(ContainerSourceSelected.args!);
+    expect(screen.getByText(/container selected/i)).toBeInTheDocument();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('DeployWizardPure — DeployStepSuccess story interactions', () => {
+  it('renders the Close button when deploy result is available', () => {
+    renderStory(DeployStepSuccess.args!);
+    expect(screen.getByRole('button', { name: /close/i })).toBeInTheDocument();
+  });
+
+  it('renders the footer action as Close (not Deploy) after a success result', () => {
+    renderStory(DeployStepSuccess.args!);
+    // When a result is shown the footer replaces the Deploy button with Close.
+    // The breadcrumb renders a "Deploy" label with role="button" on a div element;
+    // the footer action is a native <button>. We confirm the footer action is Close.
+    expect(screen.getByRole('button', { name: /close/i })).toBeInTheDocument();
+  });
+
+  it('calls onClose when Close button is clicked', () => {
+    const onClose = vi.fn();
+    renderStory(DeployStepSuccess.args!, { onClose });
+    fireEvent.click(screen.getByRole('button', { name: /close/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('DeployWizardPure — DeployStepError story interactions', () => {
+  it('renders the Close button on the deploy step after an error', () => {
+    renderStory(DeployStepError.args!);
+    expect(screen.getByRole('button', { name: /close/i })).toBeInTheDocument();
+  });
+
+  it('calls onClose when Close is clicked after an error', () => {
+    const onClose = vi.fn();
+    renderStory(DeployStepError.args!, { onClose });
+    fireEvent.click(screen.getByRole('button', { name: /close/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the footer action as Close (not Deploy) after an error result', () => {
+    renderStory(DeployStepError.args!);
+    // Same logic as success — the footer shows Close, not Deploy.
+    expect(screen.getByRole('button', { name: /close/i })).toBeInTheDocument();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('DeployWizardPure — DeployStepDeploying story interactions', () => {
+  it('renders the Deploy button with deploying text while in-flight', () => {
+    renderStory(DeployStepDeploying.args!);
+    expect(screen.getByRole('button', { name: /deploying/i })).toBeInTheDocument();
+  });
+
+  it('Deploy button is disabled while deploying', () => {
+    renderStory(DeployStepDeploying.args!);
+    expect(screen.getByRole('button', { name: /deploying/i })).toBeDisabled();
+  });
+
+  it('does not call handleDeploy when Deploy is clicked while deploying', () => {
+    const handleDeploy = vi.fn().mockResolvedValue(undefined);
+    renderStory(DeployStepDeploying.args!, { handleDeploy });
+    fireEvent.click(screen.getByRole('button', { name: /deploying/i }));
+    expect(handleDeploy).not.toHaveBeenCalled();
+  });
+
+  it('Deploy button exposes aria-busy while deploying', () => {
+    renderStory(DeployStepDeploying.args!);
+    const btn = screen.getByRole('button', { name: /deploying/i });
+    expect(btn).toHaveAttribute('aria-busy', 'true');
+  });
+});

--- a/plugins/aks-desktop/src/components/DeployWizard/components/ConfigureYAML.tsx
+++ b/plugins/aks-desktop/src/components/DeployWizard/components/ConfigureYAML.tsx
@@ -100,7 +100,11 @@ export default function ConfigureYAML({
       </Box>
 
       {yamlError && (
-        <Typography variant="body2" color="error" sx={{ mt: 1 }}>
+        /* role="alert" causes assistive technologies to immediately announce this error
+           when it is dynamically injected into the DOM (assertive live region), without
+           the user needing to navigate to it.
+           MDN: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/alert_role */
+        <Typography role="alert" variant="body2" color="error" sx={{ mt: 1 }}>
           {yamlError}
         </Typography>
       )}

--- a/plugins/aks-desktop/src/components/DeployWizard/components/Deploy.tsx
+++ b/plugins/aks-desktop/src/components/DeployWizard/components/Deploy.tsx
@@ -1,28 +1,42 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0.
 
-import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
-import MonacoEditor from '@monaco-editor/react';
-import { Box, Chip, Paper, Stack, Typography } from '@mui/material';
-import React, { useMemo } from 'react';
-import YAML from 'yaml';
+import React from 'react';
+import { useYamlObjects } from '../hooks/useYamlObjects';
+import DeployPure from './DeployPure';
 
+/**
+ * Props accepted by the {@link Deploy} connector component.
+ * These are forwarded to {@link DeployPure} together with the parsed
+ * `yamlObjects` computed by {@link useYamlObjects}.
+ */
 export interface DeployProps {
+  /** The selected deploy source; determines which content path is rendered. */
   sourceType: 'container' | 'yaml' | null;
+  /** Target namespace shown in the container-path subtitle. */
   namespace?: string;
+  /** Generated YAML for the container-source review editor (read-only Monaco). */
   containerPreviewYaml: string;
+  /**
+   * Namespace-overridden YAML prepared by the wizard for the YAML-source review.
+   * Takes precedence over `yamlEditorValue` when non-empty.
+   */
   userPreviewYaml: string;
+  /** Raw YAML text typed by the user; used as fallback when `userPreviewYaml` is empty. */
   yamlEditorValue: string;
+  /** Outcome of the last deploy attempt, or `null` before any attempt. */
   deployResult: 'success' | 'error' | null;
+  /** Human-readable message describing the deploy outcome. */
   deployMessage: string;
 }
 
-interface K8sObject {
-  kind: string;
-  name: string;
-  namespace?: string;
-}
-
+/**
+ * Thin connector that wires {@link useYamlObjects} into {@link DeployPure}.
+ *
+ * Parses `userPreviewYaml`/`yamlEditorValue` into Kubernetes resource summaries
+ * and passes the result — along with all other props — to the pure presentational
+ * component so the view remains hook-free and directly story-bookable.
+ */
 export default function Deploy({
   sourceType,
   namespace,
@@ -32,135 +46,15 @@ export default function Deploy({
   deployResult,
   deployMessage,
 }: DeployProps) {
-  const { t } = useTranslation();
-  // Parse YAML to extract object summaries
-  const yamlObjects = useMemo<K8sObject[]>(() => {
-    if (sourceType !== 'yaml') return [];
-
-    try {
-      const yamlContent = userPreviewYaml || yamlEditorValue;
-      const docs = YAML.parseAllDocuments(yamlContent);
-      return docs
-        .map(doc => {
-          const obj = doc.toJSON();
-          if (!obj || !obj.kind) return null;
-          return {
-            kind: obj.kind,
-            name: obj.metadata?.name || t('unnamed'),
-            namespace: obj.metadata?.namespace,
-          };
-        })
-        .filter(obj => obj !== null) as K8sObject[];
-    } catch (e) {
-      return [];
-    }
-  }, [sourceType, userPreviewYaml, yamlEditorValue]);
-
+  const yamlObjects = useYamlObjects(sourceType, userPreviewYaml, yamlEditorValue);
   return (
-    <Box>
-      <Typography variant="h6" gutterBottom>
-        {t('Review & Deploy')}
-      </Typography>
-      {deployResult && (
-        <Box
-          sx={{
-            mb: 1,
-            p: 1.5,
-            border: '1px solid',
-            borderColor: deployResult === 'success' ? 'success.main' : 'error.main',
-            borderRadius: 1,
-            color: deployResult === 'success' ? 'success.main' : 'error.main',
-            backgroundColor: theme =>
-              deployResult === 'success'
-                ? theme.palette.mode === 'dark'
-                  ? 'rgba(46, 125, 50, 0.12)'
-                  : 'rgba(46, 125, 50, 0.08)'
-                : theme.palette.mode === 'dark'
-                ? 'rgba(211, 47, 47, 0.12)'
-                : 'rgba(211, 47, 47, 0.08)',
-          }}
-        >
-          {deployMessage}
-        </Box>
-      )}
-      {sourceType === 'container' ? (
-        <>
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-            {t('Generated Kubernetes manifests (namespace: {{namespace}})', {
-              namespace: namespace || t('default'),
-            })}
-          </Typography>
-          <Box
-            sx={{
-              border: '1px solid',
-              borderColor: 'divider',
-              borderRadius: 1,
-              overflow: 'hidden',
-            }}
-          >
-            <MonacoEditor
-              height="60vh"
-              language="yaml"
-              value={containerPreviewYaml}
-              onChange={() => {}}
-              options={{
-                readOnly: true,
-                minimap: { enabled: false },
-                wordWrap: 'on',
-                fontSize: 13,
-                lineNumbers: 'on',
-                scrollBeyondLastLine: false,
-                renderWhitespace: 'selection',
-                automaticLayout: true,
-              }}
-            />
-          </Box>
-        </>
-      ) : (
-        <>
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-            {t('Resources to be deployed ({{count}} object)', {
-              count: yamlObjects.length,
-            })}
-          </Typography>
-          <Stack spacing={1.5}>
-            {yamlObjects.map((obj, index) => (
-              <Paper
-                key={index}
-                variant="outlined"
-                sx={{
-                  p: 2,
-                  borderRadius: 1,
-                  '&:hover': {
-                    borderColor: 'primary.main',
-                    backgroundColor: 'action.hover',
-                  },
-                }}
-              >
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-                  <Chip
-                    label={obj.kind}
-                    size="small"
-                    color="primary"
-                    sx={{ fontWeight: 600, minWidth: 120 }}
-                  />
-                  <Typography variant="body1" sx={{ fontWeight: 500, flex: 1 }}>
-                    {obj.name}
-                  </Typography>
-                  {obj.namespace && (
-                    <Chip
-                      label={`namespace: ${obj.namespace}`}
-                      size="small"
-                      variant="outlined"
-                      sx={{ fontSize: '0.75rem' }}
-                    />
-                  )}
-                </Box>
-              </Paper>
-            ))}
-          </Stack>
-        </>
-      )}
-    </Box>
+    <DeployPure
+      sourceType={sourceType}
+      namespace={namespace}
+      containerPreviewYaml={containerPreviewYaml}
+      deployResult={deployResult}
+      deployMessage={deployMessage}
+      yamlObjects={yamlObjects}
+    />
   );
 }

--- a/plugins/aks-desktop/src/components/DeployWizard/components/DeployPure.stories.tsx
+++ b/plugins/aks-desktop/src/components/DeployWizard/components/DeployPure.stories.tsx
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { Meta, StoryFn } from '@storybook/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import DeployPure, { DeployPureProps } from './DeployPure';
+
+export default {
+  title: 'DeployWizard/DeployPure',
+  component: DeployPure,
+  decorators: [
+    (Story: any) => (
+      <MemoryRouter>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
+} as Meta;
+
+const Template: StoryFn<DeployPureProps> = args => <DeployPure {...args} />;
+
+const sampleYamlObjects = [
+  { kind: 'Deployment', name: 'my-app', namespace: 'default' },
+  { kind: 'Service', name: 'my-app-svc', namespace: 'default' },
+];
+
+export const Idle = Template.bind({});
+Idle.args = {
+  sourceType: 'yaml',
+  namespace: 'default',
+  containerPreviewYaml: '',
+  deployResult: null,
+  deployMessage: '',
+  yamlObjects: sampleYamlObjects,
+};
+
+export const DeploySuccess = Template.bind({});
+DeploySuccess.args = {
+  ...Idle.args,
+  deployResult: 'success',
+  deployMessage: 'Applied 5 resources successfully.',
+};
+
+export const DeployError = Template.bind({});
+DeployError.args = {
+  ...Idle.args,
+  deployResult: 'error',
+  deployMessage:
+    'Failed to apply resources: connection refused to api-server.production.svc.cluster.local:443 (error: ECONNREFUSED)',
+};
+
+export const YamlWithObjects = Template.bind({});
+YamlWithObjects.args = {
+  ...Idle.args,
+  yamlObjects: [
+    { kind: 'Deployment', name: 'api-server', namespace: 'production' },
+    { kind: 'Service', name: 'api-server-svc' },
+    { kind: 'Ingress', name: 'api-ingress', namespace: 'production' },
+  ],
+};
+
+/** Edge case: no resources parsed from YAML. */
+export const EmptyResourceList = Template.bind({});
+EmptyResourceList.args = {
+  ...Idle.args,
+  yamlObjects: [],
+};
+
+/** Edge case: single resource — exercises singular count label. */
+export const SingleResource = Template.bind({});
+SingleResource.args = {
+  ...Idle.args,
+  yamlObjects: [{ kind: 'Deployment', name: 'web-frontend', namespace: 'production' }],
+};
+
+/** Multiple diverse resource kinds. */
+export const ManyResourceTypes = Template.bind({});
+ManyResourceTypes.args = {
+  ...Idle.args,
+  yamlObjects: [
+    { kind: 'Deployment', name: 'web-frontend', namespace: 'production' },
+    { kind: 'Service', name: 'web-frontend-svc', namespace: 'production' },
+    { kind: 'ConfigMap', name: 'app-config', namespace: 'production' },
+    { kind: 'HorizontalPodAutoscaler', name: 'web-frontend-hpa', namespace: 'production' },
+    { kind: 'ServiceAccount', name: 'web-frontend-sa', namespace: 'production' },
+  ],
+};

--- a/plugins/aks-desktop/src/components/DeployWizard/components/DeployPure.tsx
+++ b/plugins/aks-desktop/src/components/DeployWizard/components/DeployPure.tsx
@@ -1,0 +1,169 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
+import MonacoEditor from '@monaco-editor/react';
+import { Box, Chip, Paper, Stack, Typography } from '@mui/material';
+import React from 'react';
+import { K8sObject } from '../hooks/useYamlObjects';
+
+/**
+ * Pure presentational props for {@link DeployPure}.
+ * All data and callbacks come from the parent — the component itself has no
+ * stateful business-logic hooks (only `useTranslation` for i18n).
+ */
+export interface DeployPureProps {
+  /** The selected deploy source; controls which review UI is rendered. */
+  sourceType: 'container' | 'yaml' | null;
+  /** Target namespace shown in the container-path subtitle. */
+  namespace?: string;
+  /** Generated YAML for the container-source review editor (read-only Monaco). */
+  containerPreviewYaml: string;
+  /**
+   * Outcome of the deploy attempt, or `null` before any attempt.
+   * Renders a `role="alert"` box (error) or `role="status"` box (success).
+   */
+  deployResult: 'success' | 'error' | null;
+  /** Human-readable message describing the deploy outcome. */
+  deployMessage: string;
+  /** Parsed Kubernetes resource summaries shown as review cards (YAML source path). */
+  yamlObjects: K8sObject[];
+}
+
+/**
+ * Pure presentational component for the Deploy wizard review step.
+ *
+ * Renders either a Monaco editor (container source) or resource-summary cards
+ * (YAML source), plus an accessible status/error banner when a deploy result
+ * is available. Contains no stateful hooks — all business-logic state comes from props.
+ *
+ * @see {@link useYamlObjects} for the YAML parsing hook that populates `yamlObjects`.
+ * @see {@link DeployPureProps} for the full prop contract.
+ */
+
+export default function DeployPure({
+  sourceType,
+  namespace,
+  containerPreviewYaml,
+  deployResult,
+  deployMessage,
+  yamlObjects,
+}: DeployPureProps) {
+  const { t } = useTranslation();
+
+  return (
+    <Box>
+      <Typography variant="h6" gutterBottom>
+        {t('Review & Deploy')}
+      </Typography>
+      {deployResult && (
+        /* role="alert" (for errors) causes AT to immediately announce the message as an
+           assertive live region — appropriate for a failed deploy that needs urgent attention.
+           role="status" (for success) uses a polite live region so the confirmation is
+           announced without interrupting the current screen reader output.
+           Both roles ensure the result box is announced when it is dynamically inserted.
+           MDN: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/alert_role
+           MDN: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/status_role */
+        <Box
+          role={deployResult === 'error' ? 'alert' : 'status'}
+          sx={{
+            mb: 1,
+            p: 1.5,
+            border: '1px solid',
+            borderColor: deployResult === 'success' ? 'success.main' : 'error.main',
+            borderRadius: 1,
+            color: deployResult === 'success' ? 'success.main' : 'error.main',
+            backgroundColor: theme =>
+              deployResult === 'success'
+                ? theme.palette.mode === 'dark'
+                  ? 'rgba(46, 125, 50, 0.12)'
+                  : 'rgba(46, 125, 50, 0.08)'
+                : theme.palette.mode === 'dark'
+                ? 'rgba(211, 47, 47, 0.12)'
+                : 'rgba(211, 47, 47, 0.08)',
+          }}
+        >
+          {deployMessage}
+        </Box>
+      )}
+      {sourceType === 'container' ? (
+        <>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+            {t('Generated Kubernetes manifests (namespace: {{namespace}})', {
+              namespace: namespace || t('default'),
+            })}
+          </Typography>
+          <Box
+            sx={{
+              border: '1px solid',
+              borderColor: 'divider',
+              borderRadius: 1,
+              overflow: 'hidden',
+            }}
+          >
+            <MonacoEditor
+              height="60vh"
+              language="yaml"
+              value={containerPreviewYaml}
+              onChange={() => {}}
+              options={{
+                readOnly: true,
+                minimap: { enabled: false },
+                wordWrap: 'on',
+                fontSize: 13,
+                lineNumbers: 'on',
+                scrollBeyondLastLine: false,
+                renderWhitespace: 'selection',
+                automaticLayout: true,
+              }}
+            />
+          </Box>
+        </>
+      ) : (
+        <>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            {t('Resources to be deployed ({{count}} object)', {
+              count: yamlObjects.length,
+            })}
+          </Typography>
+          <Stack spacing={1.5}>
+            {yamlObjects.map((obj, index) => (
+              <Paper
+                key={`${obj.kind}|${obj.namespace ?? 'default'}|${obj.name}|${index}`}
+                variant="outlined"
+                sx={{
+                  p: 2,
+                  borderRadius: 1,
+                  '&:hover': {
+                    borderColor: 'primary.main',
+                    backgroundColor: 'action.hover',
+                  },
+                }}
+              >
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+                  <Chip
+                    label={obj.kind}
+                    size="small"
+                    color="primary"
+                    sx={{ fontWeight: 600, minWidth: 120 }}
+                  />
+                  <Typography variant="body1" sx={{ fontWeight: 500, flex: 1 }}>
+                    {obj.name}
+                  </Typography>
+                  {obj.namespace && (
+                    <Chip
+                      label={t('namespace: {{namespace}}', { namespace: obj.namespace })}
+                      size="small"
+                      variant="outlined"
+                      sx={{ fontSize: '0.75rem' }}
+                    />
+                  )}
+                </Box>
+              </Paper>
+            ))}
+          </Stack>
+        </>
+      )}
+    </Box>
+  );
+}

--- a/plugins/aks-desktop/src/components/DeployWizard/components/__tests__/DeployPure.a11y.test.tsx
+++ b/plugins/aks-desktop/src/components/DeployWizard/components/__tests__/DeployPure.a11y.test.tsx
@@ -1,0 +1,135 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+// @vitest-environment jsdom
+import { cleanup, render } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+expect.extend(toHaveNoViolations);
+
+// ── module mocks ─────────────────────────────────────────────────────────────
+// Use a real i18next instance so {{variable}} interpolation works correctly in
+// rendered output. react-i18next falls back to the global i18next instance set
+// by initReactI18next, so no I18nextProvider wrapper is needed.
+vi.mock('@kinvolk/headlamp-plugin/lib', async () => {
+  const i18n = (await import('i18next')).default;
+  const { initReactI18next, useTranslation } = await import('react-i18next');
+  if (!i18n.isInitialized) {
+    await i18n.use(initReactI18next).init({
+      lng: 'en',
+      fallbackLng: 'en',
+      resources: { en: { translation: {} } },
+      interpolation: { escapeValue: false },
+      returnEmptyString: false,
+    });
+  }
+  return { useTranslation };
+});
+
+// Monaco editor is heavyweight and not needed for a11y structure checks.
+// role="region" is required so that aria-label is permitted on a div.
+vi.mock('@monaco-editor/react', () => ({
+  default: () => <div data-testid="monaco-editor" role="region" aria-label="YAML editor" />,
+}));
+
+// ── component under test ─────────────────────────────────────────────────────
+import DeployPure, { DeployPureProps } from '../DeployPure';
+
+afterEach(() => cleanup());
+
+const sampleYamlObjects = [
+  { kind: 'Deployment', name: 'my-app', namespace: 'default' },
+  { kind: 'Service', name: 'my-app-svc', namespace: 'default' },
+];
+
+const baseArgs: DeployPureProps = {
+  sourceType: 'yaml',
+  namespace: 'default',
+  containerPreviewYaml: '',
+  deployResult: null,
+  deployMessage: '',
+  yamlObjects: sampleYamlObjects,
+};
+
+function renderInRouter(props: DeployPureProps) {
+  return render(
+    <MemoryRouter>
+      <DeployPure {...props} />
+    </MemoryRouter>
+  );
+}
+
+describe('DeployPure a11y', () => {
+  test('Idle state has no violations', async () => {
+    const { container } = renderInRouter({ ...baseArgs });
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  test('Deploy success has no violations', async () => {
+    const { container } = renderInRouter({
+      ...baseArgs,
+      deployResult: 'success',
+      deployMessage: 'Applied 2 resources successfully.',
+    });
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  test('Deploy error has no violations', async () => {
+    const { container } = renderInRouter({
+      ...baseArgs,
+      deployResult: 'error',
+      deployMessage: 'Failed to apply resources: ImagePullBackOff on container my-app.',
+    });
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  test('YAML with multiple objects has no violations', async () => {
+    const { container } = renderInRouter({
+      ...baseArgs,
+      yamlObjects: [
+        { kind: 'Deployment', name: 'api-server', namespace: 'production' },
+        { kind: 'Service', name: 'api-server-svc' },
+        { kind: 'Ingress', name: 'api-ingress', namespace: 'production' },
+      ],
+    });
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  test('Container source type has no violations', async () => {
+    const { container } = renderInRouter({
+      ...baseArgs,
+      sourceType: 'container',
+      containerPreviewYaml: 'apiVersion: apps/v1\nkind: Deployment\n',
+    });
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  test('Empty resource list has no violations', async () => {
+    const { container } = renderInRouter({
+      ...baseArgs,
+      yamlObjects: [],
+    });
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  test('Single resource has no violations', async () => {
+    const { container } = renderInRouter({
+      ...baseArgs,
+      yamlObjects: [{ kind: 'Deployment', name: 'web-frontend', namespace: 'production' }],
+    });
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  test('Deploy error with long message has no violations', async () => {
+    const { container } = renderInRouter({
+      ...baseArgs,
+      deployResult: 'error',
+      deployMessage:
+        'Failed to apply resources: connection refused to api-server.production.svc.cluster.local:443 (error: ECONNREFUSED). Retried 5 times over 30 seconds. Last attempt at 2024-01-15T10:23:45Z. Check that the API server is reachable and that your kubeconfig credentials are valid. If the issue persists, contact your cluster administrator.',
+    });
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/plugins/aks-desktop/src/components/DeployWizard/components/__tests__/DeployPure.test.tsx
+++ b/plugins/aks-desktop/src/components/DeployWizard/components/__tests__/DeployPure.test.tsx
@@ -1,0 +1,233 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+// @vitest-environment jsdom
+/**
+ * Interaction tests for {@link DeployPure}.
+ *
+ * Each test renders the component using the args from the corresponding
+ * Storybook story so that the stories act as the single source of truth for
+ * both the visual catalogue and the interaction test matrix.
+ *
+ * Pattern:
+ *   1. Import story args.
+ *   2. Spy on every callback prop (DeployPure is purely presentational with no
+ *      callbacks, so tests focus on rendered output and ARIA attributes).
+ *   3. Render via RTL.
+ *   4. Assert the correct elements are visible and accessible.
+ */
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// ── module mocks ─────────────────────────────────────────────────────────────
+vi.mock('@kinvolk/headlamp-plugin/lib', async () => {
+  const i18n = (await import('i18next')).default;
+  const { initReactI18next, useTranslation } = await import('react-i18next');
+  if (!i18n.isInitialized) {
+    await i18n.use(initReactI18next).init({
+      lng: 'en',
+      fallbackLng: 'en',
+      resources: { en: { translation: {} } },
+      interpolation: { escapeValue: false },
+      returnEmptyString: false,
+    });
+  }
+  return { useTranslation };
+});
+
+vi.mock('@monaco-editor/react', () => ({
+  default: () => <div data-testid="monaco-editor" role="region" aria-label="YAML editor" />,
+}));
+
+// ── component + stories ───────────────────────────────────────────────────────
+import DeployPure, { DeployPureProps } from '../DeployPure';
+import {
+  DeployError,
+  DeploySuccess,
+  EmptyResourceList,
+  Idle,
+  ManyResourceTypes,
+  SingleResource,
+  YamlWithObjects,
+} from '../DeployPure.stories';
+
+afterEach(() => cleanup());
+
+function renderStory(storyArgs: DeployPureProps, overrides: Partial<DeployPureProps> = {}) {
+  const props: DeployPureProps = { ...storyArgs, ...overrides };
+  return render(
+    <MemoryRouter>
+      <DeployPure {...props} />
+    </MemoryRouter>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('DeployPure — Idle story', () => {
+  it('renders the Review & Deploy heading', () => {
+    renderStory(Idle.args!);
+    expect(screen.getByRole('heading', { name: /review & deploy/i })).toBeInTheDocument();
+  });
+
+  it('shows no status banner when deployResult is null', () => {
+    renderStory(Idle.args!);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('renders the resource cards from story yamlObjects', () => {
+    renderStory(Idle.args!);
+    expect(screen.getByText('my-app')).toBeInTheDocument();
+    expect(screen.getByText('my-app-svc')).toBeInTheDocument();
+  });
+
+  it('renders namespace chips for resources that have a namespace', () => {
+    renderStory(Idle.args!);
+    // Both sample objects have namespace "default"
+    const nsChips = screen.getAllByText(/namespace: default/i);
+    expect(nsChips.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('DeployPure — DeploySuccess story', () => {
+  it('renders a polite status live region on success', () => {
+    renderStory(DeploySuccess.args!);
+    const statusBox = screen.getByRole('status');
+    expect(statusBox).toBeInTheDocument();
+  });
+
+  it('shows the success message from the story', () => {
+    renderStory(DeploySuccess.args!);
+    expect(screen.getByText(/applied 5 resources successfully/i)).toBeInTheDocument();
+  });
+
+  it('does not render an alert role on success', () => {
+    renderStory(DeploySuccess.args!);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('DeployPure — DeployError story', () => {
+  it('renders an assertive alert live region on error', () => {
+    renderStory(DeployError.args!);
+    const alertBox = screen.getByRole('alert');
+    expect(alertBox).toBeInTheDocument();
+  });
+
+  it('shows the error message from the story', () => {
+    renderStory(DeployError.args!);
+    expect(screen.getByText(/failed to apply resources/i)).toBeInTheDocument();
+    expect(screen.getByText(/ECONNREFUSED/i)).toBeInTheDocument();
+  });
+
+  it('does not render a status role on error', () => {
+    renderStory(DeployError.args!);
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('DeployPure — YamlWithObjects story', () => {
+  it('renders all three resources from the story', () => {
+    renderStory(YamlWithObjects.args!);
+    expect(screen.getByText('api-server')).toBeInTheDocument();
+    expect(screen.getByText('api-server-svc')).toBeInTheDocument();
+    expect(screen.getByText('api-ingress')).toBeInTheDocument();
+  });
+
+  it('renders kind chips for each resource', () => {
+    renderStory(YamlWithObjects.args!);
+    expect(screen.getByText('Deployment')).toBeInTheDocument();
+    expect(screen.getByText('Service')).toBeInTheDocument();
+    expect(screen.getByText('Ingress')).toBeInTheDocument();
+  });
+
+  it('only renders namespace chips for resources that have a namespace', () => {
+    renderStory(YamlWithObjects.args!);
+    // api-server-svc has no namespace in the story so no chip for it
+    const nsChips = screen.getAllByText(/namespace: production/i);
+    expect(nsChips.length).toBe(2); // api-server and api-ingress have namespace
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('DeployPure — EmptyResourceList story', () => {
+  it('renders the heading with empty list', () => {
+    renderStory(EmptyResourceList.args!);
+    expect(screen.getByRole('heading', { name: /review & deploy/i })).toBeInTheDocument();
+  });
+
+  it('renders no resource cards when yamlObjects is empty', () => {
+    renderStory(EmptyResourceList.args!);
+    // No Paper cards for resources — only the heading and resource-count text should appear
+    expect(screen.queryByText(/deployment/i)).not.toBeInTheDocument();
+  });
+
+  it('shows 0 in the resource count label', () => {
+    renderStory(EmptyResourceList.args!);
+    expect(screen.getByText(/0 object/i)).toBeInTheDocument();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('DeployPure — SingleResource story', () => {
+  it('shows 1 in the resource count label', () => {
+    renderStory(SingleResource.args!);
+    expect(screen.getByText(/1 object/i)).toBeInTheDocument();
+  });
+
+  it('renders the single resource card', () => {
+    renderStory(SingleResource.args!);
+    expect(screen.getByText('web-frontend')).toBeInTheDocument();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('DeployPure — ManyResourceTypes story', () => {
+  it('renders all five resource cards', () => {
+    renderStory(ManyResourceTypes.args!);
+    expect(screen.getByText('web-frontend')).toBeInTheDocument();
+    expect(screen.getByText('web-frontend-svc')).toBeInTheDocument();
+    expect(screen.getByText('app-config')).toBeInTheDocument();
+    expect(screen.getByText('web-frontend-hpa')).toBeInTheDocument();
+    expect(screen.getByText('web-frontend-sa')).toBeInTheDocument();
+  });
+
+  it('renders all five kind chips', () => {
+    renderStory(ManyResourceTypes.args!);
+    expect(screen.getByText('ConfigMap')).toBeInTheDocument();
+    expect(screen.getByText('HorizontalPodAutoscaler')).toBeInTheDocument();
+    expect(screen.getByText('ServiceAccount')).toBeInTheDocument();
+  });
+
+  it('renders 5 in the resource count label', () => {
+    renderStory(ManyResourceTypes.args!);
+    expect(screen.getByText(/5 object/i)).toBeInTheDocument();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('DeployPure — container sourceType', () => {
+  it('renders the Monaco editor for container source type', () => {
+    renderStory(Idle.args!, {
+      sourceType: 'container',
+      containerPreviewYaml: 'apiVersion: apps/v1\nkind: Deployment\n',
+    });
+    expect(screen.getByTestId('monaco-editor')).toBeInTheDocument();
+  });
+
+  it('shows the generated manifests subtitle for container source', () => {
+    renderStory(Idle.args!, {
+      sourceType: 'container',
+      containerPreviewYaml: 'apiVersion: apps/v1',
+      namespace: 'production',
+    });
+    expect(screen.getByText(/generated kubernetes manifests/i)).toBeInTheDocument();
+    expect(screen.getByText(/namespace: production/i)).toBeInTheDocument();
+  });
+});

--- a/plugins/aks-desktop/src/components/DeployWizard/hooks/useDeployWizard.test.ts
+++ b/plugins/aks-desktop/src/components/DeployWizard/hooks/useDeployWizard.test.ts
@@ -1,0 +1,189 @@
+// @vitest-environment jsdom
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@kinvolk/headlamp-plugin/lib', async () => {
+  const i18n = (await import('i18next')).default;
+  const { initReactI18next, useTranslation } = await import('react-i18next');
+  if (!i18n.isInitialized) {
+    await i18n.use(initReactI18next).init({
+      lng: 'en',
+      fallbackLng: 'en',
+      resources: { en: { translation: {} } },
+      interpolation: { escapeValue: false },
+      returnEmptyString: false,
+    });
+  }
+  return { useTranslation };
+});
+
+vi.mock('@kinvolk/headlamp-plugin/lib/ApiProxy', () => ({
+  apply: vi.fn(),
+}));
+
+vi.mock('../utils/namespaceOverride', () => ({
+  applyNamespaceOverride: (obj: any) => obj,
+}));
+
+vi.mock('../utils/yamlGenerator', () => ({
+  generateYamlForContainer: () => 'generated-yaml',
+}));
+
+import { apply } from '@kinvolk/headlamp-plugin/lib/ApiProxy';
+import { useDeployWizard } from './useDeployWizard';
+
+const mockApply = vi.mocked(apply);
+
+describe('useDeployWizard', () => {
+  it('has correct initial state', () => {
+    const { result } = renderHook(() => useDeployWizard({}));
+    expect(result.current.activeStep).toBe(0);
+    expect(result.current.sourceType).toBeNull();
+    expect(result.current.deploying).toBe(false);
+  });
+
+  it('handleNext advances activeStep', () => {
+    const { result } = renderHook(() => useDeployWizard({}));
+    act(() => {
+      result.current.handleNext();
+    });
+    expect(result.current.activeStep).toBe(1);
+  });
+
+  it('handleBack decrements activeStep', () => {
+    const { result } = renderHook(() => useDeployWizard({}));
+    act(() => {
+      result.current.handleNext();
+    });
+    act(() => {
+      result.current.handleBack();
+    });
+    expect(result.current.activeStep).toBe(0);
+  });
+
+  it('handleBack does not go below 0', () => {
+    const { result } = renderHook(() => useDeployWizard({}));
+    act(() => {
+      result.current.handleBack();
+    });
+    expect(result.current.activeStep).toBe(0);
+  });
+
+  it('isStepValid(0) returns false when sourceType is null', () => {
+    const { result } = renderHook(() => useDeployWizard({}));
+    expect(result.current.isStepValid(0)).toBe(false);
+  });
+
+  it('isStepValid(0) returns true when sourceType is set', () => {
+    const { result } = renderHook(() => useDeployWizard({}));
+    act(() => {
+      result.current.setSourceType('yaml');
+    });
+    expect(result.current.isStepValid(0)).toBe(true);
+  });
+
+  it('isStepValid(1) returns false when yamlEditorValue is empty with sourceType=yaml', () => {
+    const { result } = renderHook(() => useDeployWizard({}));
+    act(() => {
+      result.current.setSourceType('yaml');
+    });
+    expect(result.current.isStepValid(1)).toBe(false);
+  });
+
+  it('isStepValid(1) returns true when yamlEditorValue is non-empty with sourceType=yaml', () => {
+    const { result } = renderHook(() => useDeployWizard({}));
+    act(() => {
+      result.current.setSourceType('yaml');
+      result.current.setYamlEditorValue('apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cm');
+    });
+    expect(result.current.isStepValid(1)).toBe(true);
+  });
+
+  it('handleDeploy success path sets deployResult to success', async () => {
+    mockApply.mockResolvedValueOnce(undefined as any);
+    const { result } = renderHook(() => useDeployWizard({}));
+    act(() => {
+      result.current.setSourceType('yaml');
+      result.current.setYamlEditorValue(
+        'apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: my-cm\n  namespace: default'
+      );
+    });
+    await act(async () => {
+      await result.current.handleDeploy();
+    });
+    expect(result.current.deployResult).toBe('success');
+    expect(result.current.deploying).toBe(false);
+  });
+
+  it('handleDeploy error path sets deployResult to error', async () => {
+    mockApply.mockRejectedValueOnce(new Error('apply failed'));
+    const { result } = renderHook(() => useDeployWizard({}));
+    act(() => {
+      result.current.setSourceType('yaml');
+      result.current.setYamlEditorValue(
+        'apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: my-cm'
+      );
+    });
+    await act(async () => {
+      await result.current.handleDeploy();
+    });
+    expect(result.current.deployResult).toBe('error');
+    expect(result.current.deployMessage).toBe('apply failed');
+    expect(result.current.deploying).toBe(false);
+  });
+
+  it('handleDeploy sets deploying false after completion', async () => {
+    mockApply.mockResolvedValueOnce(undefined as any);
+    const { result } = renderHook(() => useDeployWizard({}));
+    act(() => {
+      result.current.setSourceType('yaml');
+      result.current.setYamlEditorValue(
+        'apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: my-cm'
+      );
+    });
+    await act(async () => {
+      await result.current.handleDeploy();
+    });
+    expect(result.current.deploying).toBe(false);
+  });
+
+  it('handleStepClick navigates to a previous step', () => {
+    const { result } = renderHook(() => useDeployWizard({}));
+    act(() => {
+      result.current.handleNext();
+    });
+    expect(result.current.activeStep).toBe(1);
+    act(() => {
+      result.current.handleStepClick(0);
+    });
+    expect(result.current.activeStep).toBe(0);
+  });
+
+  it('handleStepClick does not navigate while deploying is true', async () => {
+    // Start a deploy that never resolves so we can inspect state mid-flight.
+    mockApply.mockImplementation(() => new Promise(() => {}));
+    const { result } = renderHook(() => useDeployWizard({}));
+    act(() => {
+      result.current.setSourceType('yaml');
+      result.current.setYamlEditorValue(
+        'apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: my-cm'
+      );
+      result.current.handleNext();
+      result.current.handleNext();
+    });
+    // Kick off the deploy (don't await — we want the in-flight state).
+    act(() => {
+      result.current.handleDeploy().catch(() => {});
+    });
+    // deploying should be true while in flight.
+    expect(result.current.deploying).toBe(true);
+    // Attempting to navigate back to step 0 must be a no-op.
+    act(() => {
+      result.current.handleStepClick(0);
+    });
+    expect(result.current.activeStep).toBe(2);
+  });
+});

--- a/plugins/aks-desktop/src/components/DeployWizard/hooks/useDeployWizard.ts
+++ b/plugins/aks-desktop/src/components/DeployWizard/hooks/useDeployWizard.ts
@@ -1,0 +1,249 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
+import { apply } from '@kinvolk/headlamp-plugin/lib/ApiProxy';
+import React, { useEffect, useState } from 'react';
+import YAML from 'yaml';
+import { applyNamespaceOverride } from '../utils/namespaceOverride';
+import { generateYamlForContainer } from '../utils/yamlGenerator';
+import { useContainerConfiguration } from './useContainerConfiguration';
+
+/**
+ * The three ordered steps of the Deploy wizard.
+ * Used as numeric indices for `activeStep` comparisons.
+ */
+export enum WizardStep {
+  /** Step 0 — choose between YAML upload and container-image configuration. */
+  SOURCE = 0,
+  /** Step 1 — edit the YAML or fill the container-image form. */
+  CONFIGURE = 1,
+  /** Step 2 — review the generated manifests and trigger deployment. */
+  DEPLOY = 2,
+}
+
+/**
+ * Options accepted by {@link useDeployWizard}.
+ */
+export interface UseDeployWizardOptions {
+  /** Name of the target Kubernetes cluster (passed to `apply`). */
+  cluster?: string;
+  /** Target namespace; injected into generated/parsed YAML before deployment. */
+  namespace?: string;
+  /** Pre-fills the application name field in the container-configuration step. */
+  initialApplicationName?: string;
+}
+
+/**
+ * All state and event-handlers returned by {@link useDeployWizard}.
+ * Pass the whole object directly into {@link DeployWizardPure} as props.
+ */
+export interface UseDeployWizardResult {
+  /** Index of the currently active wizard step (see {@link WizardStep}). */
+  activeStep: number;
+  /** Selected deploy source, or `null` if not yet chosen. */
+  sourceType: 'yaml' | 'container' | null;
+  /** Setter for {@link sourceType}. */
+  setSourceType: React.Dispatch<React.SetStateAction<'yaml' | 'container' | null>>;
+  /** Raw YAML text in the editor. */
+  yamlEditorValue: string;
+  /** Setter for {@link yamlEditorValue}. */
+  setYamlEditorValue: React.Dispatch<React.SetStateAction<string>>;
+  /** Validation error message from the YAML editor, or `null` when valid. */
+  yamlError: string | null;
+  /** Setter for {@link yamlError}. */
+  setYamlError: React.Dispatch<React.SetStateAction<string | null>>;
+  /** `true` while the deploy API call is in-flight. */
+  deploying: boolean;
+  /** Outcome of the most recent deploy attempt, or `null` before any attempt. */
+  deployResult: 'success' | 'error' | null;
+  /** Human-readable message describing the deploy outcome. */
+  deployMessage: string;
+  /** Namespace-overridden YAML shown in the review step for the YAML source path. */
+  userPreviewYaml: string;
+  /** Full container-configuration state and setter (see `useContainerConfiguration`). */
+  containerConfig: ReturnType<typeof useContainerConfiguration>;
+  /** Advances `activeStep` by one (capped at {@link WizardStep.DEPLOY}). */
+  handleNext: () => void;
+  /** Decrements `activeStep` by one (floored at {@link WizardStep.SOURCE}). */
+  handleBack: () => void;
+  /**
+   * Navigates to `step` if it is at or before `activeStep`, or if
+   * {@link isStepValid} returns `true` for that step.
+   */
+  handleStepClick: (step: number) => void;
+  /**
+   * Validates the current YAML/container config, applies each parsed Kubernetes
+   * resource via the Headlamp API proxy, and updates {@link deployResult}.
+   */
+  handleDeploy: () => Promise<void>;
+  /**
+   * Returns `true` when the given step has sufficient data to proceed.
+   * Used to enable/disable the "Next" button and breadcrumb navigation.
+   */
+  isStepValid: (step: number) => boolean;
+}
+
+/**
+ * Manages all state and side-effects for the {@link DeployWizard}.
+ *
+ * Extracted from `DeployWizard.tsx` so it can be unit-tested independently
+ * and so that {@link DeployWizardPure} remains a pure presentational component.
+ *
+ * @param options - Cluster, namespace, initial app name, and close callback.
+ * @returns Wizard state and handlers ready to spread into {@link DeployWizardPure}.
+ */
+export function useDeployWizard({
+  cluster,
+  namespace,
+  initialApplicationName,
+}: UseDeployWizardOptions): UseDeployWizardResult {
+  const { t } = useTranslation();
+  const [activeStep, setActiveStep] = useState(WizardStep.SOURCE);
+  const [sourceType, setSourceType] = useState<null | 'yaml' | 'container'>(null);
+  const [yamlEditorValue, setYamlEditorValue] = useState<string>('');
+  const [yamlError, setYamlError] = useState<string | null>(null);
+  const [deploying, setDeploying] = useState(false);
+  const [deployResult, setDeployResult] = useState<null | 'success' | 'error'>(null);
+  const [deployMessage, setDeployMessage] = useState<string>('');
+  const [userPreviewYaml, setUserPreviewYaml] = useState<string>('');
+
+  const containerConfig = useContainerConfiguration(initialApplicationName);
+
+  useEffect(() => {
+    if (activeStep === WizardStep.DEPLOY && sourceType === 'container') {
+      containerConfig.setConfig(prev => {
+        const nextYaml = generateYamlForContainer({ ...prev, namespace });
+        // Guard: return prev unchanged if the generated YAML hasn't changed.
+        // Without this check the effect would trigger an infinite render loop
+        // because setConfig always produces a new object reference.
+        if (prev.containerPreviewYaml === nextYaml) {
+          return prev;
+        }
+        return { ...prev, containerPreviewYaml: nextYaml };
+      });
+    }
+    if (activeStep === WizardStep.DEPLOY && sourceType === 'yaml') {
+      try {
+        const text = yamlEditorValue;
+        const docs = YAML.parseAllDocuments(text).filter(d => d && d.contents);
+        const processed = docs
+          .map(d => d.toJSON())
+          .filter(Boolean)
+          .map(obj => applyNamespaceOverride(obj, namespace))
+          .map(obj => YAML.stringify(obj).trim());
+        setUserPreviewYaml(processed.join('\n---\n'));
+      } catch (e) {
+        setUserPreviewYaml(yamlEditorValue);
+      }
+    }
+    if (activeStep !== WizardStep.DEPLOY) {
+      setDeployResult(null);
+      setDeployMessage('');
+      setDeploying(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeStep, sourceType, namespace, yamlEditorValue, containerConfig.config]);
+
+  const isStepValid = (step: number): boolean => {
+    switch (step) {
+      case WizardStep.SOURCE:
+        return sourceType !== null;
+      case WizardStep.CONFIGURE:
+        if (sourceType === 'yaml') {
+          return yamlEditorValue.trim().length > 0;
+        }
+        if (sourceType === 'container') {
+          return (
+            containerConfig.config.appName.trim().length > 0 &&
+            containerConfig.config.containerImage.trim().length > 0
+          );
+        }
+        return false;
+      case WizardStep.DEPLOY:
+        return isStepValid(WizardStep.SOURCE) && isStepValid(WizardStep.CONFIGURE);
+      default:
+        return true;
+    }
+  };
+
+  const handleNext = () => setActiveStep(s => Math.min(s + 1, WizardStep.DEPLOY));
+  const handleBack = () => setActiveStep(s => Math.max(s - 1, WizardStep.SOURCE));
+  const handleStepClick = (step: number) => {
+    // Block breadcrumb navigation while a deploy is in-flight to prevent stale
+    // success/error state from being applied to a different YAML/config.
+    if (deploying) return;
+    if (step <= activeStep || isStepValid(step as WizardStep)) {
+      setActiveStep(step);
+    }
+  };
+
+  const handleDeploy = async () => {
+    try {
+      setYamlError(null);
+      setDeployResult(null);
+      setDeployMessage('');
+      setDeploying(true);
+
+      const text =
+        sourceType === 'container' ? containerConfig.config.containerPreviewYaml : yamlEditorValue;
+
+      let parsedDocs;
+      try {
+        parsedDocs = YAML.parseAllDocuments(text);
+        for (const doc of parsedDocs) {
+          const json = doc.toJSON();
+          if (!json || !json.kind || !json.metadata?.name) {
+            throw new Error(t('Invalid YAML: missing required fields (kind or metadata.name)'));
+          }
+        }
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : String(e);
+        setYamlError(msg || t('Invalid YAML'));
+        setDeployResult('error');
+        setDeployMessage(msg || t('Invalid YAML'));
+        return;
+      }
+
+      const docs = parsedDocs
+        .map(d => d.toJSON())
+        .filter(Boolean)
+        .map(obj => (sourceType === 'yaml' ? applyNamespaceOverride(obj, namespace) : obj));
+
+      let applied = 0;
+      for (const resource of docs) {
+        if (!resource || typeof resource !== 'object') continue;
+        await apply(resource as any, cluster);
+        applied++;
+      }
+      setDeployResult('success');
+      setDeployMessage(t('Applied {{count}} resource successfully.', { count: applied }));
+    } catch (e: unknown) {
+      setDeployResult('error');
+      const deployErrMsg = e instanceof Error ? e.message : String(e);
+      setDeployMessage(deployErrMsg || t('Failed to apply resources.'));
+    } finally {
+      setDeploying(false);
+    }
+  };
+
+  return {
+    activeStep,
+    sourceType,
+    setSourceType,
+    yamlEditorValue,
+    setYamlEditorValue,
+    yamlError,
+    setYamlError,
+    deploying,
+    deployResult,
+    deployMessage,
+    userPreviewYaml,
+    containerConfig,
+    handleNext,
+    handleBack,
+    handleStepClick,
+    handleDeploy,
+    isStepValid,
+  };
+}

--- a/plugins/aks-desktop/src/components/DeployWizard/hooks/useYamlObjects.test.ts
+++ b/plugins/aks-desktop/src/components/DeployWizard/hooks/useYamlObjects.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@kinvolk/headlamp-plugin/lib', async () => {
+  const i18n = (await import('i18next')).default;
+  const { initReactI18next, useTranslation } = await import('react-i18next');
+  if (!i18n.isInitialized) {
+    await i18n.use(initReactI18next).init({
+      lng: 'en',
+      fallbackLng: 'en',
+      resources: { en: { translation: {} } },
+      interpolation: { escapeValue: false },
+      returnEmptyString: false,
+    });
+  }
+  return { useTranslation };
+});
+
+import { useYamlObjects } from './useYamlObjects';
+
+describe('useYamlObjects', () => {
+  it('returns [] when sourceType is null', () => {
+    const { result } = renderHook(() => useYamlObjects(null, '', ''));
+    expect(result.current).toEqual([]);
+  });
+
+  it('returns [] when sourceType is container', () => {
+    const { result } = renderHook(() =>
+      useYamlObjects(
+        'container',
+        'apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: foo',
+        ''
+      )
+    );
+    expect(result.current).toEqual([]);
+  });
+
+  it('parses a single YAML document and returns one K8sObject', () => {
+    const yaml =
+      'apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: my-app\n  namespace: default';
+    const { result } = renderHook(() => useYamlObjects('yaml', yaml, ''));
+    expect(result.current).toEqual([{ kind: 'Deployment', name: 'my-app', namespace: 'default' }]);
+  });
+
+  it('parses multi-document YAML and returns multiple objects', () => {
+    const yaml = [
+      'apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: my-app',
+      'apiVersion: v1\nkind: Service\nmetadata:\n  name: my-svc\n  namespace: prod',
+    ].join('\n---\n');
+    const { result } = renderHook(() => useYamlObjects('yaml', yaml, ''));
+    expect(result.current).toHaveLength(2);
+    expect(result.current[0]).toEqual({ kind: 'Deployment', name: 'my-app', namespace: undefined });
+    expect(result.current[1]).toEqual({ kind: 'Service', name: 'my-svc', namespace: 'prod' });
+  });
+
+  it('returns [] on invalid YAML without throwing', () => {
+    const { result } = renderHook(() => useYamlObjects('yaml', '{{invalid: yaml: :', ''));
+    expect(result.current).toEqual([]);
+  });
+
+  it("uses t('unnamed') for documents without metadata.name", () => {
+    const yaml = 'apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  namespace: default';
+    const { result } = renderHook(() => useYamlObjects('yaml', yaml, ''));
+    expect(result.current).toEqual([{ kind: 'Deployment', name: 'unnamed', namespace: 'default' }]);
+  });
+
+  it('uses yamlEditorValue when userPreviewYaml is empty', () => {
+    const yaml = 'apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cm1';
+    const { result } = renderHook(() => useYamlObjects('yaml', '', yaml));
+    expect(result.current).toEqual([{ kind: 'ConfigMap', name: 'cm1', namespace: undefined }]);
+  });
+});

--- a/plugins/aks-desktop/src/components/DeployWizard/hooks/useYamlObjects.ts
+++ b/plugins/aks-desktop/src/components/DeployWizard/hooks/useYamlObjects.ts
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache 2.0.
+
+import { useTranslation } from '@kinvolk/headlamp-plugin/lib';
+import { useMemo } from 'react';
+import YAML from 'yaml';
+
+/**
+ * A lightweight summary of a single Kubernetes resource parsed from YAML.
+ * Used to display resource cards in the Deploy review step.
+ */
+export interface K8sObject {
+  /** The Kubernetes resource kind (e.g. `"Deployment"`, `"Service"`). */
+  kind: string;
+  /** The resource name from `metadata.name`, or `"unnamed"` if absent. */
+  name: string;
+  /** The target namespace from `metadata.namespace`, if present. */
+  namespace?: string;
+}
+
+/**
+ * Parses YAML content into a list of {@link K8sObject} summaries.
+ *
+ * Returns an empty array when `sourceType` is not `'yaml'` or when the
+ * YAML cannot be parsed, so callers never need to handle thrown errors.
+ *
+ * @param sourceType - The selected deploy source. Only `'yaml'` triggers parsing.
+ * @param userPreviewYaml - Namespace-overridden YAML prepared for the review step.
+ *   Takes precedence over `yamlEditorValue` when non-empty.
+ * @param yamlEditorValue - Raw YAML text typed by the user in the editor.
+ * @returns Parsed Kubernetes resource summaries, or `[]` on any parse failure.
+ */
+export function useYamlObjects(
+  sourceType: 'container' | 'yaml' | null,
+  userPreviewYaml: string,
+  yamlEditorValue: string
+): K8sObject[] {
+  const { t } = useTranslation();
+  return useMemo(() => {
+    if (sourceType !== 'yaml') return [];
+    try {
+      const yamlContent = userPreviewYaml || yamlEditorValue;
+      const docs = YAML.parseAllDocuments(yamlContent);
+      return docs
+        .map(doc => {
+          const obj = doc.toJSON();
+          if (!obj || !obj.kind) return null;
+          const result: K8sObject = {
+            kind: obj.kind as string,
+            name: (obj.metadata?.name || t('unnamed')) as string,
+            namespace: obj.metadata?.namespace as string | undefined,
+          };
+          return result;
+        })
+        .filter((obj): obj is K8sObject => obj !== null);
+    } catch {
+      return [];
+    }
+  }, [sourceType, userPreviewYaml, yamlEditorValue, t]);
+}


### PR DESCRIPTION
Error messages shown after a failed "Create Project" or "Deploy" operation were invisible to screen readers because the containers lacked ARIA live region attributes. Dynamically injected content is silently ignored by Narrator/NVDA without them. Additional accessibility issues across the same flows were also identified and fixed, including all `CircularProgress` loading states which were updated to follow the ARIA-recommended pattern for loading indicators.

The three affected components (`CreateAKSProject`, `Deploy`, `DeployWizard`) have been refactored into `*Pure` presentational components with extracted custom hooks, enabling isolated unit tests for logic. Automated accessibility tests using `jest-axe` have been added for all story states and run as part of the existing CI test pipeline.

## Description

Added proper ARIA roles and live region attributes to all dynamically rendered status and error containers across the Create Project and Deploy wizard flows, ensuring screen readers announce each state change. Both the Create Project error overlay and success overlay are now rendered as proper MUI `Dialog` components, which provide built-in focus trapping, focus management, and `aria-modal` handling. The error dialog uses `role="alertdialog"` (per MDN: when the user is expected to close the alert, `alertdialog` must be used instead of `alert`) because the user must interact with the Cancel button to dismiss it, and `autoFocus` is set on the Cancel button so keyboard focus moves into the dialog immediately. The success dialog uses the standard MUI `Dialog` which manages focus automatically, and its `onClose` is wired to the Cancel handler so Escape key and backdrop-click correctly close the dialog. Both dialogs preserve the original visual styling.

All `CircularProgress` loading indicators have been updated to follow the ARIA docs pattern: region-level spinners use `aria-describedby` pointing to the progress bar and `aria-busy` on the containing region; button-level decorative spinners use `aria-hidden="true"` with `aria-busy` on the button; the polling status box uses `role="status"` so AT announces the text when it appears. The Configure Cluster button now sets `aria-busy` during both `enabling` and `polling` states to give assistive tech a consistent busy signal across the full async flow.

Every accessibility change is annotated with an inline code comment explaining the reason. The full MDN and MUI reference list is consolidated here:

- **`role="alertdialog"`**: <a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/alertdialog_role">MDN alertdialog role</a> — required when the user must interact to dismiss the alert (vs. passive `alert`).
- **MUI `Dialog`** (both overlays): <a href="https://mui.com/material-ui/react-dialog/#accessibility">MUI Dialog accessibility</a> — provides built-in focus trapping, focus management, and `aria-modal` handling automatically for both the success and error dialogs.
- **`autoFocus` on Cancel in `alertdialog`**: <a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/alertdialog_role">MDN alertdialog</a> — when an alertdialog opens, focus must move into it so keyboard/screen reader users can reach the dismiss control; MUI Dialog does not auto-focus the Cancel button so `autoFocus` is set explicitly.
- **`role="alert"`**: <a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/alert_role">MDN alert role</a> — assertive live region for urgent inline notifications (deploy error).
- **`role="status"`**: <a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/status_role">MDN status role</a> — polite live region for non-urgent confirmations (deploy success, polling status).
- **`aria-busy`**: <a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-busy">MDN aria-busy</a> — set on the owning region or button while content is loading; set for both `enabling` and `polling` states on the Configure Cluster button.
- **`aria-describedby` (progress bar pattern)**: <a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/progressbar_role">MDN progressbar role</a> — the owning region points to the spinner via `aria-describedby` so AT knows which region is loading.
- **`aria-hidden="true"` (decorative spinners and icons)**: <a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-hidden">MDN aria-hidden</a> — button-level spinners, purely decorative dialog icons, and underlying card content while the loading overlay is active are hidden from AT.
- **`aria-live="polite"`**: <a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-live">MDN aria-live</a> — creation progress text updates announced without interrupting the user.
- **MUI `TextField`** (replaces native `<label>/<input>`): <a href="https://mui.com/material-ui/react-text-field/#accessibility">MUI TextField accessibility</a> — MUI manages label–input association and helper text via `htmlFor`/`aria-describedby` automatically.
- **MUI `Autocomplete` `loading` prop**: <a href="https://mui.com/material-ui/react-autocomplete/#load-on-open">MUI Autocomplete</a> — already sets `aria-busy` on the listbox; the adornment spinner is therefore decorative only.

Each component (`CreateAKSProjectPure`, `DeployPure`, `DeployWizardPure`) is a one-file-per-component presentational layer. Business logic lives in co-located hooks (`useCreateAKSProjectWizard`, `useDeployWizard`, `useYamlObjects`). All exported types, interfaces, enums, and function signatures carry TSDoc comments.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring
- [ ] CI/CD changes
- [ ] Other: ****___****

## Related Issues

Related to #[issue number]

## Changes Made

**Accessibility fixes:**
- **`CreateAKSProjectPure.tsx`** — Error overlay: replaced custom positioned Box with MUI `Dialog` (`role="alertdialog"` applied via `PaperProps` so the role and `aria-labelledby` are on the same MUI Paper element, built-in focus trap, `aria-labelledby` / `aria-describedby` pointing to `aksd-create-aks-project-*` IDs, `autoFocus` on Cancel button per MDN alertdialog spec, `aria-hidden` on decorative icon). Preserves original visual styling (64×64 icon, h5 title, scrollable monospace error box, red border, 700px wide).
- **`CreateAKSProjectPure.tsx`** — Success overlay: replaced custom positioned Box with MUI `Dialog` (built-in focus trapping and management, `aria-labelledby`, `aria-describedby`, `aria-hidden` on decorative icon, `autoFocus` on TextField, `onClose` wired to Cancel handler so Escape key and backdrop-click correctly dismiss the dialog). Success dialog description `Typography` uses `component="p"` so the h6 visual style renders as `<p>`, keeping the `h2 → p` heading hierarchy valid. Preserves original visual styling (80×80 icon, h4 title, h6 description, green border).
- **`CreateAKSProjectPure.tsx`** — Progress text: `aria-live="polite"` on `Typography` so creation status updates are announced.
- **`CreateAKSProjectPure.tsx`** — Loading overlay spinner: `id="aksd-create-aks-project-progress"` on `CircularProgress`; `aria-describedby` + `aria-busy` on the `Card`; `aria-label` corrected to `t('Creating Project')` (capital P) to match the existing translation key.
- **`CreateAKSProjectPure.tsx`** — `CardContent` now has `aria-hidden={isCreating || undefined}` to hide all underlying interactive content from AT while the loading overlay is active, preventing screen reader users from reaching controls that are visually obscured.
- **`CreateAKSProjectPure.tsx`** — Back and Cancel buttons now have `disabled={isCreating}` to prevent interaction while creation is in-flight.
- **`CreateAKSProjectPure.tsx`** — All element IDs prefixed with `aksd-create-aks-project-` for uniqueness.
- **`CreateAKSProjectPure.tsx`** — File-level docs updated: "no hooks" corrected to "no stateful business-logic hooks (only `useTranslation` for i18n)" to avoid misleading future refactors.
- **`CreateAKSProjectPure.tsx`** — "Create Project" submit button now also disabled while `isCreating` (`disabled={isCreating || !validation.isValid}`) and exposes `aria-busy={isCreating || undefined}` to prevent duplicate submissions and give AT a consistent busy signal.
- **`CreateAKSProjectPure.tsx`** — `// @ts-ignore` annotated with reason explaining that Headlamp `PageGrid` typings are incomplete at the point of use.
- **`useCreateAKSProjectWizard.ts`** — `handleStepClick` now returns early while `isCreating` is true, blocking breadcrumb navigation during an in-flight creation to prevent wizard state corruption.
- **`ClusterConfigurePanel.tsx`** — Configure Cluster button: `aria-busy` now set during both `enabling` and `polling` states (`aria-busy={enabling || polling || undefined}`) for a consistent busy signal across the full async flow.
- **`DeployPure.tsx`** — Result container: `role={deployResult === 'error' ? 'alert' : 'status'}` so error uses assertive live region and success uses polite live region.
- **`DeployPure.tsx`** — Resource list label: pluralization-safe wording using i18next plural key matching the locales file.
- **`DeployPure.tsx`** — `yamlObjects.map` key: stable `kind|namespace|name|index` composite key (index appended as discriminator to prevent collisions with duplicate YAML resources).
- **`DeployPure.tsx`** — Namespace chip label now passes through `t(...)` for correct i18n in non-English locales.
- **`useDeployWizard.ts`** — Success message: uses i18next plural support (`t('Applied {{count}} resource successfully.', { count })`) for correct singular/plural rendering.
- **`useDeployWizard.ts`** — Removed redundant `setDeploying(false)` in the YAML-parse error path; the surrounding `finally` block handles cleanup consistently.
- **`useDeployWizard.ts`** — Both `catch` blocks changed from `catch (e: any)` to `catch (e: unknown)` with `instanceof Error` guards (`e instanceof Error ? e.message : String(e)`), consistent with the rest of the codebase.
- **`BasicsStep.tsx`**, **`ClusterConfigurePanel.tsx`**, **`DeployWizardPure.tsx`** — All inline button-level `CircularProgress` spinners: `aria-hidden="true"` (decorative; button label conveys state) + `aria-busy` on the owning button.
- **`SearchableSelect.tsx`** — Autocomplete adornment spinner: `aria-hidden="true"` (MUI `loading` prop already manages `aria-busy` on the listbox).
- **`ConfigureYAML.tsx`** — YAML validation error `Typography`: `role="alert"` so screen readers announce validation failures.

**Security / privacy fixes:**
- **`useCreateAKSProjectWizard.ts`** — All `console.log` / `console.warn` debug statements that printed `formData`, subscription IDs, resource groups, and assignee emails are now gated behind a `DEBUG = false` constant defined at the top of each module; they are silent by default in production.
- **`useCreateAKSProjectWizard.ts`** — `console.error('Error details:', ...)` no longer includes the raw `formData` object; replaced with `formDataRedacted: true` to prevent accidental exposure of sensitive data in error logs.
- **`useNamespaceCheck.ts`**, **`BasicsStep.tsx`**, **`CreateAKSProjectPure.tsx`** — All verbose debug `console.log` calls similarly gated behind per-module `DEBUG = false` constants.
- **`useCreateAKSProjectWizard.ts`** — `catch (userError)` now uses the `instanceof Error` guard (`userError instanceof Error ? userError.message : String(userError)`) consistent with every other catch block in the hook.

**Bug fixes (review feedback):**
- **`useCreateAKSProjectWizard.ts`** — Fixed leaked `setTimeout` in `Promise.race`: `creationTimeoutId` is now captured and `clearTimeout` called in a `finally` block so the timer never fires after a race is already settled.
- **`useCreateAKSProjectWizard.ts`** — Fixed untracked 2s `setTimeout` used to open the success dialog: the timeout ID is now stored in a `useRef` and cleared via a `useEffect` cleanup so the callback never fires on an unmounted component, eliminating the React "setState on unmounted component" warning and the associated memory leak.
- **`useCreateAKSProjectWizard.ts`** — All `catch` blocks now guard against non-`Error` thrown values: `error instanceof Error ? error.message : String(error)` and `error instanceof Error ? error.stack : undefined` used throughout (outer catch, `finalError` catch, `statusError` catch, and `userError` catch) so error handling can never itself throw and lose the original failure.
- **`useDeployWizard.ts`** — Fixed potential infinite render loop in the container-config preview YAML effect: `setConfig` is now guarded with an equality check so it only updates state when `containerPreviewYaml` actually changes.
- **`useDeployWizard.ts`** — Removed unused `onClose` from `UseDeployWizardOptions` (the connector passes it directly to `DeployWizardPure`; the hook never used it).
- **`useDeployWizard.ts`** — Updated TSDoc reference from `DeployWizardView` → `DeployWizardPure`.
- **`useCreateAKSProjectWizard.ts`** — `creationTimeoutId` type corrected to `number` (browser `setTimeout` return type) to fix a TypeScript compilation error.
- **`CreateAKSProjectPureProps`** — `handleSubmit` typed as `() => Promise<void>` (was `() => void`) to accurately reflect the async hook implementation.
- **`useCreateAKSProjectWizard.ts`** — TSDoc corrected: stale `CreateAKSProjectView` references updated to `CreateAKSProjectPure` to match the actual presentational component name.
- **`useCreateAKSProjectWizard.test.ts`** — Success-path test refactored to use `vi.runAllTimersAsync()` instead of advancing fake timers by 10 minutes, making the test deterministic and resilient to implementation changes.
- **`locales/en/translation.json`** and all other locale files — Added missing `"namespace: {{namespace}}"` translation key so the namespace chip label in `DeployPure` is fully localized rather than falling back to the raw English key string.
- **`useDeployWizard.ts`** — `handleStepClick` now blocks breadcrumb navigation while a deploy is in-flight (`deploying === true`) to prevent stale success/error results from being applied to a different YAML/config context after the user has navigated away.

**Dependency cleanup:**
- Removed unused `@storybook/test-runner` and `axe-playwright` devDependencies (were not referenced in any scripts or config).

**Automated accessibility testing:**
- Added `jest-axe` a11y tests (`CreateAKSProjectPure.a11y.test.tsx`, `DeployPure.a11y.test.tsx`, `DeployWizardPure.a11y.test.tsx`) covering all story states (idle, loading, error, success) — axe assertions in `CreateAKSProjectPure.a11y.test.tsx` run against `document.body` so MUI Dialog portal content (error/success dialogs) is included in every scan; the `region` axe rule is disabled for these component-level tests (components are not full pages and are not required to be wrapped in landmark regions).
- Stories enriched with more realistic data (real-looking project names, error messages, and resource names) and additional edge-case stories (empty resource list, single resource, long multiline errors, validation states).
- **`CreateAKSProjectPure.stories.tsx`** — Added `ErrorOverlayScrollable` story with very long, realistic multi-step Kubernetes failure output (namespace creation, RBAC, network policy, quota errors across multiple retries) to exercise the scrollable monospace error box in the error dialog.
- Additional unit test edge cases added to exercise boundary conditions, including `handleStepClick` navigation guard tests verifying that step changes are blocked while deploying is true.
- All test files now use a real `i18next` + `react-i18next` instance (initialized via an async `vi.mock` factory) instead of the previous `t: (key) => key` stub, so interpolated strings such as `Your AKS project "my-project" has been created and is ready to use.` render correctly in every test render.

**Refactoring:**
- `CreateAKSProject`, `Deploy`, and `DeployWizard` split into `*Pure` presentational components + co-located `useXxx` hooks + thin connector components.
- TSDoc comments on all exported types, interfaces, enums, and function signatures.
- `storybook-static/` added to `.gitignore`.
- `react-redux` overridden to 9.x in `package.json` to resolve a peer dependency conflict introduced by the hook extraction; no API changes visible to application code.
- Renamed `*.interaction.test.tsx` files to `*.test.tsx` (`CreateAKSProjectPure.test.tsx`, `DeployPure.test.tsx`, `DeployWizardPure.test.tsx`) — the `.interaction.` infix was not a meaningful distinction.
- lint, `tsc`, and format checks all pass cleanly.

## Testing

- [x] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed
- [ ] Performance tested (if applicable)
- [x] Accessibility tested (if applicable)

### Test Cases

1. Screen reader (Narrator/NVDA) announces error message after failed Create Project operation.
2. Screen reader announces success state and focus moves into success dialog when project creation completes.
3. Screen reader announces error dialog and focus moves to Cancel button when project creation fails; pressing Enter/Space on Cancel dismisses the dialog.
4. Escape key and backdrop-click on the success dialog correctly dismiss it (via wired `onClose` handler).
5. Screen reader announces Deploy error with assertive (`role="alert"`) and success with polite (`role="status"`) live region.
6. Screen reader announces YAML validation errors in the ConfigureYAML editor.
7. AT receives `aria-busy` signal during both enabling and polling phases of Configure Cluster.
8. Decorative `CircularProgress` spinners are not announced by screen readers (`aria-hidden="true"`).
9. `jest-axe` automated axe-core scans pass for all story states across `CreateAKSProjectPure`, `DeployPure`, and `DeployWizardPure` — `CreateAKSProjectPure` scans run against `document.body` so dialog portal content is fully covered; the `region` rule is disabled for component-level tests (runs in CI via `npm test`).
10. Edge-case stories verified: empty resource list, single resource, long multiline error messages, YAML validation error state.
11. `ErrorOverlayScrollable` story verified: very long realistic Kubernetes failure trace renders in the scrollable monospace error box without overflow or layout issues.
12. Keyboard users cannot trigger duplicate Create Project submissions: the submit button is disabled and `aria-busy` while `isCreating` is true.
13. Non-`Error` thrown values (strings, plain objects) are safely handled in all `catch` blocks — error handling can never itself throw and lose the original failure.
14. Interpolated strings (e.g. `Your AKS project "my-project" has been created and is ready to use.`) render correctly in all test renders — confirmed by switching to a real i18next instance in test mocks. All tests pass across all test files.
15. Debug logging is silent by default: verified that no subscription IDs, resource groups, project names, or assignee emails appear in production console output; `DEBUG = false` gates are in place in every affected module.
16. Navigating wizard steps while a deploy is in-flight is now blocked: `handleStepClick` returns early when `deploying` is true, preventing stale async results from corrupting wizard state after navigation.
17. Namespace chip label correctly renders the localized `"namespace: {{namespace}}"` key rather than falling back to the raw English string in non-English locales.
18. Component unmount during the 2s success-dialog delay no longer triggers a React "setState on unmounted component" warning — the timeout ID is stored in a `useRef` and cleared in a `useEffect` cleanup.
19. While `isCreating`, the underlying `CardContent` is hidden from AT via `aria-hidden`; Back/Cancel buttons are disabled; and `handleStepClick` blocks breadcrumb navigation — preventing all interaction with controls visually obscured by the loading overlay.
20. `handleDeploy` catch blocks now use `catch (e: unknown)` with `instanceof Error` guards, consistent with the rest of the codebase and type-safe.

## Screenshots/Videos

### CreateAKSProject — Error Dialog (`role="alertdialog"`, MUI Dialog, red border, 64×64 icon, h5 title, scrollable monospace error box, autoFocus Cancel)
<img src="https://github.com/user-attachments/assets/3d2ffc92-2733-4b4e-b2aa-398fcba0a602">

### CreateAKSProject — Success Dialog (MUI Dialog, green border, 80×80 icon, h4 title, h6 description, autoFocus TextField, onClose wired)
<img src="https://github.com/user-attachments/assets/03214ae8-9323-4cf2-a1c2-41d64c354b10">

### CreateAKSProject — Loading Overlay (card-level spinner, aria-live progress text, aria-busy on Card, aria-hidden on underlying CardContent)
<img src="https://github.com/user-attachments/assets/7ead80b8-d286-45e5-8e10-068845656171">

### Deploy — Error (`role="alert"` assertive live region)
<img src="https://github.com/user-attachments/assets/b28ec381-dc03-40e2-8612-07e0330bfbc5">

### Deploy — Success (`role="status"` polite live region)
<img src="https://github.com/user-attachments/assets/9bdf572a-046c-4585-bd87-315440c336c3">

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Breaking Changes

No breaking changes. The dialogs are functionally equivalent to before — same visual appearance, same user interactions, same props interface. The underlying implementation has been upgraded from custom positioned overlays to MUI `Dialog` components to gain built-in accessibility (focus trapping, focus management, `aria-modal`). The success dialog now additionally responds to Escape key and backdrop-click via a wired `onClose` handler, which is consistent with standard MUI Dialog behaviour. The "Create Project" submit button is now additionally disabled while a creation is in-flight, which prevents duplicate submissions and is consistent with the existing `validation.isValid` gate. Breadcrumb step navigation is now blocked while a creation or deploy is in-flight — this is a UX safety guard, not a breaking API change.

## Performance Impact

- [x] No performance impact

## Documentation Updates

- [x] Code comments updated
- [x] No documentation updates needed

## Reviewer Notes

Both dialogs in `CreateAKSProjectPure.tsx` are now MUI `Dialog` components and are visually identical to the previous custom overlays. The error dialog applies `role="alertdialog"` via `PaperProps` so the role and `aria-labelledby` land on the same MUI Paper element (fixes the `aria-dialog-name` axe rule). The success dialog description `Typography` uses `component="p"` so its h6 visual styling renders as a `<p>` element, keeping the `h2 → p` heading order valid (fixes the `heading-order` axe rule). The error dialog explicitly sets `autoFocus` on the Cancel button per the MDN `alertdialog` spec. The success dialog's `onClose` is wired to the same Cancel handler so Escape key and backdrop-click correctly update state. All a11y attribute additions are annotated with inline comments explaining the ARIA rationale.

The new `ErrorOverlayScrollable` story in `CreateAKSProjectPure.stories.tsx` provides a very long, realistic multi-step Kubernetes failure trace (namespace creation failure, RBAC errors, network policy rejection, resource quota exhaustion across multiple retries) to exercise and visually verify the scrollable monospace error box in the error dialog under production-like conditions.

The three `*.interaction.test.tsx` files have been renamed to `*.test.tsx` (`CreateAKSProjectPure.test.tsx`, `DeployPure.test.tsx`, `DeployWizardPure.test.tsx`). The `.interaction.` infix provided no meaningful distinction from regular unit tests in this codebase and has been removed for consistency.

The "Create Project" submit button is now `disabled={isCreating || !validation.isValid}` with `aria-busy={isCreating || undefined}` so keyboard users cannot trigger duplicate submissions while creation is in-flight, and AT receives a consistent busy signal. The Back and Cancel buttons are also `disabled={isCreating}` to prevent navigation behind the loading overlay. The `CardContent` is `aria-hidden={isCreating || undefined}` to hide all underlying interactive content from AT while the overlay is visible. `handleStepClick` returns early when `isCreating` is true to block breadcrumb navigation mid-creation.

The 2s `setTimeout` that opens the success dialog now stores its ID in a `useRef` and is cleared via a `useEffect` cleanup, so if the component unmounts (navigation, plugin unload) before the timer fires, the state update is suppressed and no React "setState on unmounted component" warning is emitted.

Both `catch` blocks in `useDeployWizard.ts`'s `handleDeploy` have been updated from `catch (e: any)` to `catch (e: unknown)` with `instanceof Error` guards, consistent with the pattern used throughout `useCreateAKSProjectWizard.ts` and the rest of the codebase.

All `catch` blocks in `useCreateAKSProjectWizard.ts` — including the newly guarded `catch (userError)` path — now use `instanceof Error` guards before accessing `.message`, preventing secondary throws when non-`Error` values are rejected. The `console.error('Error details:', ...)` call no longer includes raw `formData`; sensitive fields are replaced with `formDataRedacted: true`. All verbose `console.log` and `console.warn` debug statements across `useCreateAKSProjectWizard.ts`, `useNamespaceCheck.ts`, `BasicsStep.tsx`, and `CreateAKSProjectPure.tsx` are gated behind a per-module `DEBUG = false` constant and are silent by default.

The namespace chip label in `DeployPure.tsx` is now localized via `t(...)` and a corresponding `"namespace: {{namespace}}"` key has been added to all locale JSON files so the label is fully translatable in every supported locale. `handleStepClick` in both `useCreateAKSProjectWizard.ts` and `useDeployWizard.ts` now returns early when creation/deploy is in-flight, preventing stale async results from corrupting wizard state after navigation.

The `jest-axe` a11y tests in `CreateAKSProjectPure.a11y.test.tsx` run against `document.body` so all MUI Dialog portal content is included in every axe scan; the `region` rule is disabled via `axeConfig` for these component-level tests since isolated components are not full pages and are not required to be wrapped in landmark regions. The `useCreateAKSProjectWizard` TSDoc has been corrected to reference `CreateAKSProjectPure` (was stale `CreateAKSProjectView`). The success-path unit test uses `vi.runAllTimersAsync()` for deterministic timer flushing. Unused `@storybook/test-runner` and `axe-playwright` devDependencies have been removed. The `react-redux` override (8.x → 9.x) in `package.json` was required to resolve a peer dependency conflict surfaced during the hook extraction refactor; it has no visible API impact on application code. lint, `tsc`, and format checks all pass cleanly.
